### PR TITLE
[DEVOPS-121] Cardano sl faster build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { pkgs ? (import <nixpkgs> {})
 , compiler ? pkgs.haskell.packages.ghc802
+, builder-threads ? 8
 }:
 
 with (import <nixpkgs/pkgs/development/haskell-modules/lib.nix> { inherit pkgs;});
@@ -11,13 +12,13 @@ let
   });
   socket-io-src = pkgs.fetchgit (removeAttrs (lib.importJSON ./pkgs/engine-io.json) ["date"]);
   cardano-sl-src = pkgs.fetchgit (removeAttrs (lib.importJSON ./pkgs/cardano-sl.json) ["date"]);
-  cores   = 4;
-  threads = 8;
+
+  builder-cores   = builtins.div builder-threads 2;
   buildSubset = subset: drv: overrideCabal drv (drv: {
     buildTarget = subset;
   });
   buildSpeedupFlagsMarlowScaling = drv : appendConfigureFlag drv
-    "--ghc-option=-rtsopts --ghc-option=+RTS --ghc-option=-N${toString threads} --ghc-option=-A128m --ghc-option=-n2m --ghc-option=-qb0 --ghc-option=-qn${toString cores} --ghc-option=-RTS";
+    "--ghc-option=-rtsopts --ghc-option=+RTS --ghc-option=-N${toString builder-threads} --ghc-option=-A128m --ghc-option=-n2m --ghc-option=-qb0 --ghc-option=-qn${toString builder-cores} --ghc-option=-RTS";
 in compiler.override {
   overrides = self: super: {
     # To generate these go to ./pkgs and run ./generate.sh

--- a/default.nix
+++ b/default.nix
@@ -72,7 +72,7 @@ in compiler.override {
     });
     cardano-sl-static =
       buildSpeedupFlagsMarlowScaling
-      (buildSubset ("cardano-node")
+      (# buildSubset ("cardano-node") -- unfortunately, we need customizing the .cabal file for this to work..
        (dontCheck (linkWithGold (justStaticExecutables self.cardano-sl))));
     cardano-report-server-static = justStaticExecutables self.cardano-report-server;
     cardano-sl-explorer-static = justStaticExecutables self.cardano-sl-explorer;

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
     "owner":  "NixOS",
     "repo":   "nixpkgs",
-    "rev":    "464c79ea9f929d1237dbc2df878eedad91767a72",
-    "sha256": "05kkm978bfai3krsjn6h310xj7q0022bbh7a80kdizglqfkj8krw"
+    "rev":    "3e47e6251930294711d625a8123b7f395dd16b58",
+    "sha256": "026q9bd4mkk2hwibsss3yh3df483a4ira28vb7zsy54rrx1zy21p"
 }

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,6 @@ ghc       = ghcOrig.override (oldArgs: {
   let parent = (oldArgs.overrides or (_: _: {})) new old;
   in with new; parent // {
       intero         = overhub  old.intero "commercialhaskell/intero" "e546ea086d72b5bf8556727e2983930621c3cb3c" "1qv7l5ri3nysrpmnzfssw8wvdvz0f6bmymnz1agr66fplazid4pn" { doCheck = false; };
-      turtle_1_3_0   = doJailbreak old.turtle_1_3_0;
     };
   });
 
@@ -25,7 +24,7 @@ ghc       = ghcOrig.override (oldArgs: {
 ###
 drvf =
 { mkDerivation, stdenv, src ? ./.
-, base, turtle_1_3_0, cassava, vector, safe, aeson, yaml, lens-aeson
+, base, turtle, cassava, vector, safe, aeson, yaml, lens-aeson
 }:
 mkDerivation {
   pname = "iohk-nixops";
@@ -35,7 +34,7 @@ mkDerivation {
   isExecutable = true;
   doHaddock = false;
   executableHaskellDepends = [
-   base turtle_1_3_0 cassava vector safe aeson yaml lens-aeson
+   base turtle cassava vector safe aeson yaml lens-aeson
   ];
   # description  = "Visual mind assistant";
   license      = stdenv.lib.licenses.agpl3;

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,12 @@ mkDerivation {
    base turtle cassava vector safe aeson yaml lens-aeson
   ];
   license      = stdenv.lib.licenses.agpl3;
+
+  shellHook =
+  ''
+    export NIX_PATH=nixpkgs=${nixpkgs}
+    echo   NIX_PATH=$NIX_PATH
+  '';
 };
 
 drv = (pkgs.haskell.lib.addBuildTools

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,16 @@
-{ pkgs     ? import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))) {}
-, compiler ? pkgs.haskell.packages.ghc802
+let
+  nixpkgs  = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
+  pkgs     = import nixpkgs {};
+in
+{ compiler ? pkgs.haskell.packages.ghc802
 , intero   ? false
 }:
 
 let
 
 ghcOrig   = import ./default.nix { inherit pkgs compiler; };
-overcabal = pkgs.haskell.lib.overrideCabal;
 hubsrc    =      repo: rev: sha256:       pkgs.fetchgit { url = "https://github.com/" + repo; rev = rev; sha256 = sha256; };
-overc     = old:                    args: overcabal old (oldAttrs: (oldAttrs // args));
+overc     = old:                    args: pkgs.haskell.lib.overrideCabal old (oldAttrs: (oldAttrs // args));
 overhub   = old: repo: rev: sha256: args: overc old ({ src = hubsrc repo rev sha256; }       // args);
 overhage  = old: version:   sha256: args: overc old ({ version = version; sha256 = sha256; } // args);
 ghc       = ghcOrig.override (oldArgs: {
@@ -36,7 +38,6 @@ mkDerivation {
   executableHaskellDepends = [
    base turtle cassava vector safe aeson yaml lens-aeson
   ];
-  # description  = "Visual mind assistant";
   license      = stdenv.lib.licenses.agpl3;
 };
 

--- a/shell.nix
+++ b/shell.nix
@@ -49,10 +49,11 @@ mkDerivation {
 
 drv = (pkgs.haskell.lib.addBuildTools
 (ghc.callPackage drvf { })
-(if intero
- then [ pkgs.cabal-install
-        pkgs.stack
-        ghc.intero ]
- else []));
+((if intero
+  then [ pkgs.cabal-install
+         pkgs.stack
+         ghc.intero ]
+  else [ ]) ++
+ [ pkgs.nix ]));
 
 in drv.env


### PR DESCRIPTION
Besides _partially_ addressing https://issues.serokell.io/issue/DEVOPS-36#comment=96-3716, this also sets up `NIX_PATH`, so that a number of tools needn't have `-I` specified -- and so this pulls towards unification of `nixpkgs` specification (don't remember the issue).

cc @domenkozar, @jmitchell 

TODO:

- [x] decide on testing being a part of all Hydra builds
- [x] decide on whether building all 13 executables is worth it for all Hydra builds