### PR TITLE
DEVOPS-218: make `scripts/aws.hs s3 set-daedalus-release-build` also provide version texts

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6848,8 +6848,8 @@ self: {
           pname = "servant-server";
           version = "0.10";
           sha256 = "0g87g48p179v1j3ki3vsvkk5gidqfp5yb9xwnh0j90v7x8ilvlcr";
-          revision = "1";
-          editedCabalFile = "4332581ae3248c16017f88461abf6eef9fbad2ca86e86a2e8a013f9adc665973";
+          revision = "2";
+          editedCabalFile = "39175e589dfcbd833cb9a244b8516a2357d143c10b872f52ae8bd5c3c66d6b1a";
           isLibrary = true;
           isExecutable = true;
           setupHaskellDepends = [
@@ -7033,8 +7033,8 @@ self: {
           pname = "servant";
           version = "0.10";
           sha256 = "07ik9ddaj1vmq37dl4mg00rawa9phfapm8a52cs1b5km5fxaknp1";
-          revision = "2";
-          editedCabalFile = "6808bd35e2105f94f1290066a773cd302eb0c01c987e6e933de1fc5fb05f398f";
+          revision = "3";
+          editedCabalFile = "c7bf0617bf1399ae156312c24258df7571c87ac8a15e2d0a1ea23f7d4edfae80";
           setupHaskellDepends = [
             base
             Cabal

--- a/scripts/aws.hs
+++ b/scripts/aws.hs
@@ -68,21 +68,21 @@ data S3Command
   | SetDaedalusReleaseBuild (RSpec OSX) (RSpec Win64)
   deriving (Show)
 
-parserBuildId :: Parser BuildId
-parserBuildId =
-  (BuildId         <$> argText "build-id"      "Daedalus build id.  Example: '0.3.1526'")
+parserBuildId :: ArgName -> Parser BuildId
+parserBuildId metavar =
+  (BuildId    <$> argText metavar       "Daedalus build id.  Example: '0.3.1526'")
 
 parserAppveyorId :: Parser AppveyorId
 parserAppveyorId =
-  (AppveyorId <$> argText "appveyor-path" "AppVeyor build subpath.  Example: 'iw5m0firsneia7k2/artifacts/installers/daedalus-win64-0.3.1451.0'")
+  (AppveyorId <$> argText "APPVEYOR-ID" "AppVeyor build subpath.  Example: 'iw5m0firsneia7k2'")
 
 parser ∷ Parser Command
 parser =
   subcommand "s3" "Control the S3-related AWS-ities."
   (S3 <$> (subcommand "set-daedalus-release-build" "Set the S3 daedalus-<OS>-latest.<EXT> redirect to a particular version."
             (SetDaedalusReleaseBuild
-             <$> (R_OSX   <$> parserBuildId)
-             <*> (R_Win64 <$> parserBuildId <*> parserAppveyorId))
+             <$> (R_OSX   <$> parserBuildId "OSX-BUILD-ID")
+             <*> (R_Win64 <$> parserBuildId "WIN64-BUILD-ID" <*> parserAppveyorId))
            <|>
            subcommand "check-daedalus-release-urls" "Check the Daedalus release URLs." (pure CheckDaedalusReleaseURLs))
       <*> (fromMaybe default'bucket

--- a/scripts/stack.yaml
+++ b/scripts/stack.yaml
@@ -1,0 +1,16 @@
+##
+## ATTENTION with regard to this file:
+##
+##  1. it is not intended to be used for building things -- only Nix is supported for that purpose
+##  2. its only purpose is to facilitate 'intero' working inside nix-shell, and the following content
+##     was carefully crafted to that end -- please, don't change it without ensuring that:
+##     - 'intero' continues to work inside nix-shell, and
+##     - it doesn't have to rebuild Haskell dependencies that nix-shell already provided
+##
+nix:
+  enable: false
+system-ghc: true
+resolver: ghc-8.0.2
+packages:
+- '../iohk'
+project-root: ../iohk


### PR DESCRIPTION
Test scenario:

```
[nix-shell:~/iohk]$ scripts/aws.hs s3 --bucket daedalus-travis-test set-daedalus-release-build
 0.5.1994 0.5.2110.0 v9cnlytcf5my4g2u
Setting Daedalus release redirects to:
  OS X:   https://s3.eu-central-1.amazonaws.com/daedalus-travis/Daedalus-installer-0.5.1994.pkg
  Win64:  https://ci.appveyor.com/api/buildjobs/v9cnlytcf5my4g2u/artifacts/installers/daedalus-
win64-0.5.2110.0-installer.exe

============== Checking if OSX build URL is live:
Spider mode enabled. Check if remote file exists.
--2017-07-27 01:07:54--  https://s3.eu-central-1.amazonaws.com/daedalus-travis/Daedalus-install
er-0.5.1994.pkg
Resolving s3.eu-central-1.amazonaws.com (s3.eu-central-1.amazonaws.com)... 52.219.72.32
Connecting to s3.eu-central-1.amazonaws.com (s3.eu-central-1.amazonaws.com)|52.219.72.32|:443..
. connected.
HTTP request sent, awaiting response... 200 OK
Length: 84334287 (80M) [application/octet-stream]
Remote file exists.

Both URLs live, proceeding to update latest release build references to:
  OS X:  https://s3.eu-central-1.amazonaws.com/daedalus-travis/Daedalus-installer-0.5.1994.pkg
  Win64: https://ci.appveyor.com/api/buildjobs/v9cnlytcf5my4g2u/artifacts/installers/daedalus-win64-0.5.2110.0-installer.exe

{
    "ETag": "\"26ce8d1c8bf5bb7fd1a36ebc745a1872\""
}
Done.  Following URLs should be live within a minute:

  OS X:   http://daedalus-travis-test.s3-website.eu-central-1.amazonaws.com/daedalus-osx-latest.pkg
  Win64:  http://daedalus-travis-test.s3-website.eu-central-1.amazonaws.com/daedalus-win64-latest.exe
```

Version JSON (for `daedalus-travis-test` bucket): https://s3.eu-central-1.amazonaws.com/daedalus-travis-test/daedalus-latest-version.json