### PR TITLE
Fix SSE3 support in qemu

### DIFF
--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.cardano-node;
   name = "cardano-node";
   stateDir = "/var/lib/cardano-node/";
-  cardano = (import ./../default.nix { inherit pkgs; }).cardano-sl-static;
+  cardano = (import ./../default.nix { }).cardano-sl-static;
   distributionParam = "(${toString cfg.genesisN},${toString cfg.totalMoneyAmount})";
   rnpDistributionParam = "(${toString cfg.genesisN},50000,${toString cfg.totalMoneyAmount},0.99)";
   smartGenIP = builtins.getEnv "SMART_GEN_IP";

--- a/tests/simple-node.nix
+++ b/tests/simple-node.nix
@@ -3,6 +3,7 @@ import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }: {
   nodes = {
     machine = { config, pkgs, ... }: {
       imports = [ (import ../modules/cardano-node-config.nix 0 "") ];
+      virtualisation.qemu.options = [ "-cpu Haswell" ];
       services.cardano-node = {
         autoStart = true;
         initialKademliaPeers = [];


### PR DESCRIPTION
- virtualize Haswell instructions (including SSE3)
- use fixed pkgs, not the one provided by tests