### PR TITLE
Use exact match on Datadog process monitor for "cardano_node"

### DIFF
--- a/modules/cardano-node-staging.nix
+++ b/modules/cardano-node-staging.nix
@@ -28,7 +28,7 @@ with (import ./../lib.nix);
     instances:
     - name: cardano-node
       search_string: ['cardano-node']
-      exact_match: False
+      exact_match: True
       thresholds:
         critical: [1, 1]
   '';


### PR DESCRIPTION
On staging we discovered this monitor picking up on false
positives. When `exact_match == False` the command's arguments are
included in the search, meaning `journalctl -f -u cardano-node` would
be a match. That triggers the monitor because the monitor expects
exactly 1 cardano-node process per node at any given moment.

Enabling `exact_match` means the comparison only involves the process'
name. Until we see false positives related to multiple concurrent
cardano-node processes, I'm not loosening the "exactly one match"
invariant.