### PR TITLE
[DEVOPS-333] allow the nix expressions to work with a blank NIX_PATH

### DIFF
--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,0 +1,32 @@
+/* Fetch pinned nixpkgs without external dependencies on existing nixpkgs
+   To be superseeded in Nix 1.12 with fetchTarball having a hash argument
+   to avoid re-downloading the tarball.
+*/
+let
+  # fetch nixpkgs and give the expected hash
+  unpackTar = input: let
+    nixcfg = import <nix/config.nix>;
+    script = ''
+      export PATH=$coreutils
+      $coreutils/mkdir $out
+      cd $out
+      $gzip -d < $input | $tar -x --strip-components=1
+    '';
+  in builtins.derivation {
+    system = builtins.currentSystem;
+    name = "${input.name}-unpacked";
+    builder = nixcfg.shell;
+    args = [ (builtins.toFile "builder" script) ];
+    inherit input;
+    coreutils = builtins.storePath nixcfg.coreutils;
+    tar = builtins.storePath nixcfg.tar;
+    gzip = builtins.storePath nixcfg.gzip;
+  };
+  fetchNixpkgsTarWithNix = let
+    spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+  in import <nix/fetchurl.nix> {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    inherit (spec) sha256;
+  };
+in
+  unpackTar fetchNixpkgsTarWithNix

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -52,10 +52,8 @@ in {
     binaryCaches = trustedBinaryCaches;
     binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
-  system.extraSystemBuilderCmds = let
-    setNixpkgs = fetchNixpkgsWithNixpkgs pkgs;
-  in ''
-    ln -sv ${setNixpkgs} $out/nixpkgs
+  system.extraSystemBuilderCmds = ''
+    ln -sv ${fetchNixPkgs} $out/nixpkgs
   '';
 
   # Mosh

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -2,5 +2,5 @@
     "owner":  "NixOS",
     "repo":   "nixpkgs",
     "rev":    "31a956f18c9251064997085fd7732562b1854726",
-    "sha256": "09i6shmj2slbzcsq4f06xjafwxkd2y5sjpbzpqfa147dhz9xbng6"
+    "sha256": "19xpdpbw7yn9im6npdr3pdjl2bgkj07k5w0qwymlpxksk4p77nah"
 }

--- a/scripts/set_nixpath.sh
+++ b/scripts/set_nixpath.sh
@@ -1,11 +1,7 @@
 
 update_NIX_PATH() {
-  if [ "x$NIX_PATH_LOCKED" == "x1" ]; then
-    return
-  fi
   local scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
   nix-build "${scriptDir}/../lib.nix" -A fetchNixPkgs -o "${scriptDir}/iohk-nixpkgs"
   export NIX_PATH="nixpkgs=${scriptDir}/iohk-nixpkgs"
-  export NIX_PATH_LOCKED=1
 }
 update_NIX_PATH


### PR DESCRIPTION
this change allows the nix expressions to work with a blank NIX_PATH variable, so there is no chance for impurities to leak in

once tested under such a situation, it is safe to ignore NIX_PATH, and just leave it as-is on any system

todo:
* [ ] update `iohk-ops set-rev` to handle the new hash for nixpkgs (the tar hash, rather then the unpacked hash)
* [ ] update stack2nix to do the same: https://github.com/input-output-hk/stack2nix/pull/59