### PR TITLE
re-add kvm feature to hydra slaves

### DIFF
--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -8,7 +8,7 @@ let
     sshKey = "/etc/nix/id_buildfarm";
     sshUser = "root";
     system = "x86_64-linux";
-    supportedFeatures = [ "nixos-test" ];
+    supportedFeatures = [ "kvm" "nixos-test" ];
   };
   mkLinux = hostName: commonBuildMachineOpt // {
     inherit hostName;


### PR DESCRIPTION
while EC2 machines lack kvm support, the nixos tests still require kvm,
or they refuse to even start
and they sanely fallback to softmmu if kvm isnt available