### PR TITLE
fix github status plugin

### DIFF
--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -68,7 +68,7 @@ in {
         input-output-hk = ${builtins.readFile ../static/github_token}
       </github_authorization>
       <githubstatus>
-        jobs = serokell:.*
+        jobs = serokell:iohk-nixops.*
         inputs = jobsets
         excludeBuildFromContext = 1
       </githubstatus>


### PR DESCRIPTION
the first regex to match will take all jobs, and prevent any further
status entries from running