### PR TITLE
[DEVOPS-341] Fix YAML indentation in nix file

### DIFF
--- a/modules/cardano-staging.nix
+++ b/modules/cardano-staging.nix
@@ -24,6 +24,7 @@ params:
     - name: cardano-node-simple
       search_string: ['cardano-node']
       '') + ''
+    # nix string indentation hack (see DEVOPS-341)
       exact_match: False
       thresholds:
         critical: [1, 1]


### PR DESCRIPTION
As explained in the ticket, I verified indentation is the source of the bug. This is a potential fix, although it still needs to be verified.