### PR TITLE
[DEVOPS-354] Remove dconfig at compile time

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
     "url": "https://github.com/input-output-hk/cardano-sl",
     "fetchSubmodules": "true",
-    "sha256": "15srvnhga6963dj4bs9ydgl5b3s8nkganz61znkg2lg05a7019sa",
-    "rev": "ba1f8945c7f35720bc3dadbec4ab8eda81b33c14"
+    "sha256": "1hsbhh4197daq3zl0z2g2sl82xa45ac0n25hzs77z9kn6jzgv4kf",
+    "rev": "8ce44b4df80e098342c411e03b7faaa22cd2c3fc"
 }

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,6 @@ in
 , config ? {}
 , pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
 , compiler ? pkgs.haskell.packages.ghc802
-, dconfig ? "testnet_staging_full"
 }:
 
 with pkgs.lib;
@@ -19,7 +18,6 @@ let
   cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);
   cardano-sl-pkgs = import (pkgs.fetchgit cardano-sl-src) {
                       gitrev = cardano-sl-src.rev;
-                      inherit dconfig;
                     };
 in {
   nixops = 

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -786,7 +786,7 @@ deploy o@Options{..} c@NixopsConfig{..} dryrun buonly check rebuildExplorerFront
   let dconfig = deplArg c (NixParam "dconfig") $ errorT $
           format "'dconfig' network argument missing from cluster config"
   when (not dryrun && elem Explorer cElements && rebuildExplorerFrontend) $ do
-    cmd o "scripts/generate-explorer-frontend.sh" [nixValueStr dconfig]
+    cmd o "scripts/generate-explorer-frontend.sh" []
   when (not (dryrun || buonly)) $ do
     deployerIP <- establishDeployerIP o oDeployerIP
     export "SMART_GEN_IP" $ getIP deployerIP

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -4,7 +4,7 @@ globals: params:
 { config, pkgs, lib, ... }:
 
 let
-  explorer-drv = (import ./../default.nix { inherit (config.deployment.arguments) dconfig; }).cardano-sl-explorer-static;
+  explorer-drv = (import ./../default.nix {}).cardano-sl-explorer-static;
 in
 {
   global.dnsHostname   = mkForce   "cardano-explorer";

--- a/modules/cardano-service.nix
+++ b/modules/cardano-service.nix
@@ -6,8 +6,7 @@ let
   cfg = config.services.cardano-node;
   name = "cardano-node";
   stateDir = "/var/lib/cardano-node/";
-  cardano = (import ./../default.nix { dconfig = builtins.trace ("cardano: DCONFIG is: " + config.deployment.arguments.dconfig)
-                                                 config.deployment.arguments.dconfig; }).cardano-sl-static;
+  cardano = (import ./../default.nix {}).cardano-sl-static;
   distributionParam = "(${toString cfg.genesisN},${toString cfg.totalMoneyAmount})";
   rnpDistributionParam = "(${toString cfg.genesisN},50000,${toString cfg.totalMoneyAmount},0.99)";
   smartGenIP = builtins.getEnv "SMART_GEN_IP";

--- a/modules/report-server.nix
+++ b/modules/report-server.nix
@@ -24,7 +24,7 @@ in {
       };
       executable = mkOption {
         type = types.package;
-        default = (import ./../default.nix { inherit (config.deployment.arguments) dconfig; }).cardano-report-server-static;
+        default = (import ./../default.nix {}).cardano-report-server-static;
       };
     };
   };

--- a/scripts/generate-explorer-frontend.sh
+++ b/scripts/generate-explorer-frontend.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p git jq
 
-dconfig="$1"
-
 set -euo pipefail
 
-test -n "${dconfig}" || {
-        echo "generate-explorer-frontend.sh: missing dconfig as first argument." >&2
-        exit 1
-}
-
 cardano_rev="$(jq -r .rev < cardano-sl-src.json)"
-explorer_path="$(nix-build -A cardano-sl-explorer-static --argstr dconfig ${dconfig} default.nix)"
+explorer_path="$(nix-build -A cardano-sl-explorer-static default.nix)"
 
 echo "Building explorer frontend from 'cardano-sl' repository revision:  ${cardano_rev}".
 


### PR DESCRIPTION
@deepfire this is counterpart to https://github.com/input-output-hk/cardano-sl/pull/1587/commits/c1005df36a0f873a3477cee7bf76e1057a2147d9 already in the upstream genesis brannch

As soon as we bump cardano-1.0 this will be needed (otherwise you'll get an error that `dconfig` input does not exist)