### PR TITLE
Minor monitor fixes

### DIFF
--- a/modules/datadog-monitors.nix
+++ b/modules/datadog-monitors.nix
@@ -79,7 +79,7 @@ rec {
   ntp_monitor = {
     name = "Clock out of sync with NTP";
     type = "service check";
-    query = config: "\"ntp.in_sync\".over(\"{env:${config.deployment.name}}\").by(\"host\").last(2).count_by_status()";
+    query = config: "\"ntp.in_sync\".over(\"env:${config.deployment.name}\").by(\"host\").last(2).count_by_status()";
     monitorOptions.thresholds = {
       critical = 1;
     };


### PR DESCRIPTION
@jmitchell found some extra braces in the NTP monitor definition: https://input-output-rnd.slack.com/files/U3TUV412R/F79EMNXDX/monitor-scope-braces-before.png

No idea where those came from.