### PR TITLE
topology update

### DIFF
--- a/topology-production.yaml
+++ b/topology-production.yaml
@@ -143,126 +143,7 @@ nodes:
     public: false
 
 
-# now we have 28 public relays, 7 per region
-
-  'p-a-1':
-    region: eu-central-1
-    zone: eu-central-1a
-    type: relay
-    org: IOHK
-    host: p-a-1.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-2':
-    region: eu-central-1
-    zone: eu-central-1a
-    type: relay
-    org: IOHK
-    host: p-a-2.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-3':
-    region: eu-central-1
-    zone: eu-central-1b
-    type: relay
-    org: IOHK
-    host: p-a-3.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-4':
-    region: eu-central-1
-    zone: eu-central-1b
-    type: relay
-    org: IOHK
-    host: p-a-4.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-5':
-    region: eu-central-1
-    zone: eu-central-1c
-    type: relay
-    org: IOHK
-    host: p-a-5.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-6':
-    region: eu-central-1
-    zone: eu-central-1c
-    type: relay
-    org: IOHK
-    host: p-a-6.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
-
-  'p-a-7':
-    region: eu-central-1
-    zone: eu-central-1c
-    type: relay
-    org: IOHK
-    host: p-a-7.cardano
-    dynamic-subscribe: [[{ "host": "r-d-1.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
-    kademlia: false
-    public: true
+# now we have 28 public relays, split between ap-northeast-1 and ap-southeast-1
 
   'p-b-1':
     region: ap-northeast-1
@@ -270,15 +151,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-1.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-d-1 },
+                         { "host": r-a-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-2 },
+                         { "host": r-c-1 },
+                         { "host": r-a-1 }]
+                       ]
     kademlia: false
     public: true
 
@@ -288,15 +168,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-2.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-d-1 },
+                         { "host": r-c-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-a-1 },
+                         { "host": r-a-2 },
+                         { "host": r-c-1 }]
+                       ]
     kademlia: false
     public: true
 
@@ -306,15 +185,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-3.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-d-1 },
+                         { "host": r-c-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-a-1 }]
+                       ]
     kademlia: false
     public: true
 
@@ -324,69 +202,184 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-4.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-a-2 },
+                         { "host": r-c-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-2 },
+                         { "host": r-a-1 },
+                         { "host": r-d-1 }]
+                       ]
     kademlia: false
     public: true
 
   'p-b-5':
     region: ap-northeast-1
-    zone: ap-northeast-1c
+    zone: ap-northeast-1a
     type: relay
     org: IOHK
     host: p-b-5.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-c-1 },
+                         { "host": r-a-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-d-1 },
+                         { "host": r-a-2 },
+                         { "host": r-c-2 }]
+                       ]
     kademlia: false
     public: true
 
   'p-b-6':
     region: ap-northeast-1
-    zone: ap-northeast-1c
+    zone: ap-northeast-1a
     type: relay
     org: IOHK
     host: p-b-6.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-c-2 },
+                         { "host": r-d-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-a-2 },
+                         { "host": r-a-1 },
+                         { "host": r-c-1 }]
+                       ]
     kademlia: false
     public: true
 
   'p-b-7':
     region: ap-northeast-1
-    zone: ap-northeast-1c
+    zone: ap-northeast-1a
     type: relay
     org: IOHK
     host: p-b-7.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-d-1 },
+                         { "host": r-c-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-a-1 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-8':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-8.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-d-1 },
+                         { "host": r-c-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-2 },
+                         { "host": r-a-2 },
+                         { "host": r-a-1 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-9':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-9.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-a-1 },
+                         { "host": r-c-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-c-2 },
+                         { "host": r-d-1 },
+                         { "host": r-a-2 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-10':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-10.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-c-1 },
+                         { "host": r-c-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-d-1 },
+                         { "host": r-a-1 },
+                         { "host": r-a-2 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-11':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-11.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-a-1 },
+                         { "host": r-c-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-a-2 },
+                         { "host": r-c-2 },
+                         { "host": r-d-1 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-12':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-12.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-c-1 },
+                         { "host": r-a-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-a-1 },
+                         { "host": r-c-2 },
+                         { "host": r-d-1 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-13':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-13.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-a-1 },
+                         { "host": r-c-1 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-d-1 },
+                         { "host": r-c-2 },
+                         { "host": r-a-2 }]
+                       ]
+    kademlia: false
+    public: true
+
+  'p-b-14':
+    region: ap-northeast-1
+    zone: ap-northeast-1c
+    type: relay
+    org: IOHK
+    host: p-b-14.cardano
+    dynamic-subscribe: [[{ "host": r-b-1 },
+                         { "host": r-a-1 },
+                         { "host": r-c-2 }],
+                        [{ "host": r-b-2 },
+                         { "host": r-a-2 },
+                         { "host": r-d-1 },
+                         { "host": r-c-1 }]
+                       ]
     kademlia: false
     public: true
 
@@ -396,14 +389,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-1.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-b-2 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 },
+                         { "host": r-d-1 }]
+                       ]
     kademlia: false
     public: true
 
@@ -413,14 +406,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-2.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-b-2 },
+                         { "host": r-b-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-1 },
+                         { "host": r-d-1 },
+                         { "host": r-a-2 }]
+                       ]
     kademlia: false
     public: true
 
@@ -430,14 +423,14 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-3.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-d-1 },
+                         { "host": r-a-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-2 },
+                         { "host": r-b-1 },
+                         { "host": r-b-2 }]
+                       ]
     kademlia: false
     public: true
 
@@ -447,183 +440,184 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-4.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-b-2 },
+                         { "host": r-a-2 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-d-1 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 }]
+                       ]
     kademlia: false
     public: true
 
   'p-c-5':
     region: ap-southeast-1
-    zone: ap-southeast-1b
+    zone: ap-southeast-1a
     type: relay
     org: IOHK
     host: p-c-5.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-b-2 },
+                         { "host": r-a-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-2 },
+                         { "host": r-d-1 },
+                         { "host": r-b-1 }]
+                       ]
     kademlia: false
     public: true
 
   'p-c-6':
     region: ap-southeast-1
-    zone: ap-southeast-1b
+    zone: ap-southeast-1a
     type: relay
     org: IOHK
     host: p-c-6.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-d-1 },
+                         { "host": r-a-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-b-1 },
+                         { "host": r-b-2 },
+                         { "host": r-a-2 }]
+                       ]
     kademlia: false
     public: true
 
   'p-c-7':
     region: ap-southeast-1
-    zone: ap-southeast-1b
+    zone: ap-southeast-1a
     type: relay
     org: IOHK
     host: p-c-7.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-d-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-b-2 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-1':
-    region: us-east-2
-    zone: us-east-2a
+  'p-c-8':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-1.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-8.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-d-1 },
+                         { "host": r-b-2 },
+                         { "host": r-a-2 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-2':
-    region: us-east-2
-    zone: us-east-2a
+  'p-c-9':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-2.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-9.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-b-2 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-d-1 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-3':
-    region: us-east-2
-    zone: us-east-2b
+  'p-c-10':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-3.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-10.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-1 },
+                         { "host": r-d-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-b-2 },
+                         { "host": r-b-1 },
+                         { "host": r-a-2 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-4':
-    region: us-east-2
-    zone: us-east-2b
+  'p-c-11':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-4.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-11.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-d-1 },
+                         { "host": r-b-2 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-1 },
+                         { "host": r-b-1 },
+                         { "host": r-a-2 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-5':
-    region: us-east-2
-    zone: us-east-2c
+  'p-c-12':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-5.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-12.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-1 },
+                         { "host": r-d-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-b-2 },
+                         { "host": r-a-2 },
+                         { "host": r-b-1 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-6':
-    region: us-east-2
-    zone: us-east-2c
+  'p-c-13':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-6.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-13.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-a-2 },
+                         { "host": r-b-2 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-d-1 },
+                         { "host": r-b-1 },
+                         { "host": r-a-1 }]
+                       ]
     kademlia: false
     public: true
 
-  'p-d-7':
-    region: us-east-2
-    zone: us-east-2c
+  'p-c-14':
+    region: ap-southeast-1
+    zone: ap-southeast-1b
     type: relay
     org: IOHK
-    host: p-d-7.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-d-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    host: p-c-14.cardano
+    dynamic-subscribe: [[{ "host": r-c-1 },
+                         { "host": r-b-1 },
+                         { "host": r-a-1 }],
+                        [{ "host": r-c-2 },
+                         { "host": r-a-2 },
+                         { "host": r-d-1 },
+                         { "host": r-b-2 }]
+                       ]
     kademlia: false
     public: true
+

--- a/topology-production.yaml
+++ b/topology-production.yaml
@@ -151,13 +151,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-1.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-d-1 },
-                         { "host": r-a-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-2 },
-                         { "host": r-c-1 },
-                         { "host": r-a-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-a-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -168,13 +168,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-2.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-d-1 },
-                         { "host": r-c-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-a-1 },
-                         { "host": r-a-2 },
-                         { "host": r-c-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-c-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -185,13 +185,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-3.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-d-1 },
-                         { "host": r-c-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-a-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-a-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -202,13 +202,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-4.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-a-2 },
-                         { "host": r-c-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-2 },
-                         { "host": r-a-1 },
-                         { "host": r-d-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-c-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-d-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -219,13 +219,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-5.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-c-1 },
-                         { "host": r-a-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-d-1 },
-                         { "host": r-a-2 },
-                         { "host": r-c-2 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-a-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-c-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -236,13 +236,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-6.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-c-2 },
-                         { "host": r-d-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-a-2 },
-                         { "host": r-a-1 },
-                         { "host": r-c-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -253,13 +253,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-7.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-d-1 },
-                         { "host": r-c-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-a-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-a-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -270,13 +270,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-8.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-d-1 },
-                         { "host": r-c-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-2 },
-                         { "host": r-a-2 },
-                         { "host": r-a-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-a-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -287,13 +287,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-9.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-a-1 },
-                         { "host": r-c-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-c-2 },
-                         { "host": r-d-1 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -304,13 +304,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-10.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-c-1 },
-                         { "host": r-c-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-d-1 },
-                         { "host": r-a-1 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-c-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -321,13 +321,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-11.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-a-1 },
-                         { "host": r-c-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-a-2 },
-                         { "host": r-c-2 },
-                         { "host": r-d-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -338,13 +338,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-12.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-c-1 },
-                         { "host": r-a-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-a-1 },
-                         { "host": r-c-2 },
-                         { "host": r-d-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -355,13 +355,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-13.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-a-1 },
-                         { "host": r-c-1 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-d-1 },
-                         { "host": r-c-2 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-1.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-2.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -372,13 +372,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-b-14.cardano
-    dynamic-subscribe: [[{ "host": r-b-1 },
-                         { "host": r-a-1 },
-                         { "host": r-c-2 }],
-                        [{ "host": r-b-2 },
-                         { "host": r-a-2 },
-                         { "host": r-d-1 },
-                         { "host": r-c-1 }]
+    dynamic-subscribe: [[{ "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-c-2.cardano"}],
+                        [{ "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-c-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -389,13 +389,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-1.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-b-2 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 },
-                         { "host": r-d-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-b-2.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-d-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -406,13 +406,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-2.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-b-2 },
-                         { "host": r-b-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-1 },
-                         { "host": r-d-1 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-b-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -423,13 +423,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-3.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-d-1 },
-                         { "host": r-a-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-2 },
-                         { "host": r-b-1 },
-                         { "host": r-b-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-b-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -440,13 +440,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-4.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-b-2 },
-                         { "host": r-a-2 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-d-1 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -457,13 +457,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-5.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-b-2 },
-                         { "host": r-a-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-2 },
-                         { "host": r-d-1 },
-                         { "host": r-b-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-b-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -474,13 +474,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-6.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-d-1 },
-                         { "host": r-a-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-b-1 },
-                         { "host": r-b-2 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -491,13 +491,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-7.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-d-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-b-2 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-d-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -508,13 +508,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-8.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-d-1 },
-                         { "host": r-b-2 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -525,13 +525,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-9.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-b-2 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-d-1 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-b-2.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -542,13 +542,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-10.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-1 },
-                         { "host": r-d-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-b-2 },
-                         { "host": r-b-1 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-d-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -559,13 +559,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-11.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-d-1 },
-                         { "host": r-b-2 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-1 },
-                         { "host": r-b-1 },
-                         { "host": r-a-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-b-2.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-a-2.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -576,13 +576,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-12.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-1 },
-                         { "host": r-d-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-b-2 },
-                         { "host": r-a-2 },
-                         { "host": r-b-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-1.cardano"},
+                         { "host":"r-d-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-b-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-b-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -593,13 +593,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-13.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-a-2 },
-                         { "host": r-b-2 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-d-1 },
-                         { "host": r-b-1 },
-                         { "host": r-a-1 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-b-2.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"}]
                        ]
     kademlia: false
     public: true
@@ -610,13 +610,13 @@ nodes:
     type: relay
     org: IOHK
     host: p-c-14.cardano
-    dynamic-subscribe: [[{ "host": r-c-1 },
-                         { "host": r-b-1 },
-                         { "host": r-a-1 }],
-                        [{ "host": r-c-2 },
-                         { "host": r-a-2 },
-                         { "host": r-d-1 },
-                         { "host": r-b-2 }]
+    dynamic-subscribe: [[{ "host":"r-c-1.cardano"},
+                         { "host":"r-b-1.cardano"},
+                         { "host":"r-a-1.cardano"}],
+                        [{ "host":"r-c-2.cardano"},
+                         { "host":"r-a-2.cardano"},
+                         { "host":"r-d-1.cardano"},
+                         { "host":"r-b-2.cardano"}]
                        ]
     kademlia: false
     public: true

--- a/topology-staging.yaml
+++ b/topology-staging.yaml
@@ -138,8 +138,8 @@ nodes:
 # now we have 3 unprivileged relays, one in each region
 
   'u-a-1':
-    region: eu-central-1
-    zone:   eu-central-1b
+    region: ap-northeast-1
+    zone:   ap-northeast-1a
     type: relay
     org: IOHK
     host: u-a-1.cardano

--- a/topology-staging.yaml
+++ b/topology-staging.yaml
@@ -143,14 +143,13 @@ nodes:
     type: relay
     org: IOHK
     host: u-a-1.cardano
-    dynamic-subscribe: [[{ "host": "r-a-1.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-3.cardano" }
-                       , { "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": "r-a-1.cardano" },
+                         { "host": "r-a-3.cardano" },
+                         { "host": "r-b-1.cardano" }],
+                        [{ "host": "r-a-2.cardano" },
+                         { "host": "r-c-1.cardano" },
+                         { "host": "r-b-2.cardano" }]
+                       ]
     kademlia: false
     public: true
 
@@ -160,15 +159,13 @@ nodes:
     type: relay
     org: IOHK
     host: u-b-1.cardano
-    dynamic-subscribe: [[{ "host": "r-b-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-a-3.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-c-1.cardano" }
-                       ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": "r-b-1.cardano" },
+                         { "host": "r-c-1.cardano" },
+                         { "host": "r-a-3.cardano" }],
+                        [{ "host": "r-b-2.cardano" },
+                         { "host": "r-a-2.cardano" },
+                         { "host": "r-c-2.cardano" }]
+                       ]
     kademlia: false
     public: true
 
@@ -178,13 +175,12 @@ nodes:
     type: relay
     org: IOHK
     host: u-c-1.cardano
-    dynamic-subscribe: [[{ "host": "r-c-1.cardano" }
-                       , { "host": "r-c-2.cardano" }
-                       , { "host": "r-a-3.cardano" }
-                       , { "host": "r-a-2.cardano" }
-                       , { "host": "r-a-1.cardano" }
-                       , { "host": "r-b-2.cardano" }
-                       , { "host": "r-b-1.cardano" } ]]
-    valency: 2
+    dynamic-subscribe: [[{ "host": "r-c-1.cardano" },
+                         { "host": "r-b-1.cardano" },
+                         { "host": "r-a-3.cardano" }],
+                        [{ "host": "r-c-2.cardano" },
+                         { "host": "r-a-2.cardano" },
+                         { "host": "r-b-2.cardano" }]
+                       ]
     kademlia: false
     public: true


### PR DESCRIPTION
Given the proposed change for the DNS subscription worker https://github.com/input-output-hk/cardano-sl/pull/1668 to fix CSL-1700, we would need a topology update. Here is one to check carefully.

We changed the DNS policy mechanism so it behaves like the static routes with the outer list being multiple subscriptions (valency) and the inner being alternatives (backups) for each other.

The policy here is to use primary relays from the same region first, and for fallbacks use relays (ordered randomly) from other regions. The random ordering is to avoid concentrating load upon failures.

In addition, this includes the change to put all the unprivileged relays in Tokyo and Singapore (2 AZs in each region).