### PR TITLE
[DEVOPS-406] Bump cardano restarts from 6h to 36h

### DIFF
--- a/modules/cardano-service.nix
+++ b/modules/cardano-service.nix
@@ -169,16 +169,17 @@ in {
 
     # Workaround for CSL-1320
     systemd.services.cardano-restart = let
-      getDailyTime = nodeIndex: let
-          # how many minutes between each node restarting
-          minute = mod (nodeIndex * 4) 60;
-        # Reboot cardano-node every 6h, offset by node id (in ${interval} minute intervals)
-        in "0/6:${toString minute}";
+      # how many minutes between nodes restarting
+      nodeMinute = mod (cfg.nodeIndex * 4) 60;
     in {
       script = ''
         /run/current-system/sw/bin/systemctl restart cardano-node
       '';
-      startAt = getDailyTime cfg.nodeIndex;
+      # Reboot cardano-node every 36h (except Mon->Tue gap which is 24h)
+      startAt = [
+        "Tue,Fri,Mon 13:${toString nodeMinute}"
+        "Thu,Sun     01:${toString nodeMinute}"
+      ];
     };
 
     systemd.services.cardano-node = {


### PR DESCRIPTION
The time specs were tested using a local unit file/timer, but haven't been tested in this codebase yet. We need to deploy to staging, wait until at least one restart has occurred, and audit the `LAST` and `NEXT` of `systemctl list-timers` for correctness.