### PR TITLE
Devops 410 iohk ops

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,7 @@ in {
              (compiler.callPackage ./iohk/default.nix {})
              (drv: {
                 executableToolDepends = [ pkgs.makeWrapper ];
+                libraryHaskellDepends = iohk-ops-extra-runtime-deps;
                 postInstall = ''
                   wrapProgram $out/bin/iohk-ops \
                   --prefix PATH : "${pkgs.lib.makeBinPath iohk-ops-extra-runtime-deps}"

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,9 @@ with pkgs.haskell.lib;
 let
   iohk-ops-extra-runtime-deps = [
     pkgs.git pkgs.nix-prefetch-scripts compiler.yaml
+    pkgs.wget pkgs.awscli # for scripts/aws.hs
+    pkgs.nodejs           # for cardano-sl/scripts/js/genesis-hash.js
+                          #     ..which also needs `npm install blakejs canonical-json`
   ];
   # we allow on purpose for cardano-sl to have it's own nixpkgs to avoid rebuilds
   cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);

--- a/deployments/infrastructure.nix
+++ b/deployments/infrastructure.nix
@@ -31,6 +31,8 @@ in {
       ./../modules/common.nix
     ];
 
+    environment.systemPackages = [ iohk-pkgs.iohk-ops ];
+
     users = {
       users.staging = {
         description     = "cardano staging";

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 { localLib ? import ./lib.nix
 , pkgs ? import (localLib.fetchNixPkgs) {}
+, io-dev-mode ? false
 }:
 
 let
@@ -8,7 +9,15 @@ let
       nodejs       # for cardano-sl/scripts/js/genesis-hash.js
                    #     ..which also needs `npm install blakejs canonical-json`
     ];
-  drv = pkgs.haskell.lib.overrideCabal
-         (import ./default.nix {}).iohk-ops
-         (drv: { libraryHaskellDepends = extraDeps; });
-in drv.env
+  iohk-ops = pkgs.haskell.lib.overrideCabal
+             (import ./default.nix {}).iohk-ops
+             (drv: { libraryHaskellDepends = extraDeps; });
+  ioAlias = if io-dev-mode
+            then ''runhaskell -iiohk iohk/iohk-ops.hs''
+            else ''${iohk-ops}/bin/iohk-ops'';
+in pkgs.lib.overrideDerivation iohk-ops.env
+   (old: {
+     shellHook = ''
+       alias io='${ioAlias}'
+     '';
+    })

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,8 @@ let
 in pkgs.lib.overrideDerivation iohk-ops.env
    (old: {
      shellHook = ''
-       alias io='${ioAlias}'
+       io () {
+        ${ioAlias} "$@"
+       }
      '';
     })

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,9 @@
 
 let
   extraDeps = with pkgs;
-    [ wget awscli nodejs # for scripts/aws.hs
+    [ wget awscli  # for scripts/aws.hs
+      nodejs       # for cardano-sl/scripts/js/genesis-hash.js
+                   #     ..which also needs `npm install blakejs canonical-json`
     ];
   drv = pkgs.haskell.lib.overrideCabal
          (import ./default.nix {}).iohk-ops

--- a/shell.nix
+++ b/shell.nix
@@ -4,17 +4,10 @@
 }:
 
 let
-  extraDeps = with pkgs;
-    [ wget awscli  # for scripts/aws.hs
-      nodejs       # for cardano-sl/scripts/js/genesis-hash.js
-                   #     ..which also needs `npm install blakejs canonical-json`
-    ];
-  iohk-ops = pkgs.haskell.lib.overrideCabal
-             (import ./default.nix {}).iohk-ops
-             (drv: { libraryHaskellDepends = extraDeps; });
-  ioAlias = if io-dev-mode
-            then ''runhaskell -iiohk iohk/iohk-ops.hs''
-            else ''${iohk-ops}/bin/iohk-ops'';
+  iohk-ops = (import ./default.nix {}).iohk-ops;
+  ioAlias  = if io-dev-mode
+             then ''runhaskell -iiohk iohk/iohk-ops.hs''
+             else ''${iohk-ops}/bin/iohk-ops'';
 in pkgs.lib.overrideDerivation iohk-ops.env
    (old: {
      shellHook = ''


### PR DESCRIPTION
`nix-shell` will alias `io` to a binary build of `iohk-ops`
`nix-shell --arg io-dev-mode true` will alias `io` to an interpreted version

All variants source `iohk-ops` from the current definition.