### PR TITLE
 [DEVOPS-455] implement S3 bucket storage for report-server logs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,8 +19,8 @@ let
       nixopsUnstable = pkgs.fetchFromGitHub {
         owner = "NixOS";
         repo = "nixops";
-        rev = "c06c0e79ab8d7a58d80b1c38b7ae4ed1a04322f0";
-        sha256 = "1fly6ry7ksj7v5rl27jg5mnxdbjwn40kk47gplyvslpvijk65m4q";
+        rev = "379b1f933b930aafc8d386d8bfec97ce0e775628";
+        sha256 = "0f21p1rlb3cmj6g43v185rh5abx23nj1zx5fizfpsqmswd3yl9k8";
       };
     in (import "${nixopsUnstable}/release.nix" {}).build.${system};
   iohk-ops-extra-runtime-deps = [

--- a/deployments/report-server-bucket-storage.nix
+++ b/deployments/report-server-bucket-storage.nix
@@ -4,6 +4,7 @@
   # this file will create an S3 bucket, and IAM role with access to that bucket
   # then give the report-server machine access to that role, and mount the bucket within the instance
   report-server = { pkgs, resources, ... }: {
+    # nixops can only set this at creation, it will need to be manualy set
     deployment.ec2.instanceProfile = resources.iamRoles.report-role.name;
     fileSystems."/var/lib/report-server" = {
       # mount unsets PATH when running this

--- a/deployments/report-server-bucket-storage.nix
+++ b/deployments/report-server-bucket-storage.nix
@@ -1,0 +1,59 @@
+{ IOHKaccessKeyId, ... }:
+
+{
+  # this file will create an S3 bucket, and IAM role with access to that bucket
+  # then give the report-server machine access to that role, and mount the bucket within the instance
+  report-server = { pkgs, resources, ... }: {
+    deployment.ec2.instanceProfile = resources.iamRoles.report-role.name;
+    fileSystems."/var/lib/report-server" = {
+      # mount unsets PATH when running this
+      device = "/run/current-system/sw/bin/s3fs#${resources.s3Buckets.report-bucket-3.name}";
+      fsType = "fuse";
+      options = [ "_netdev" "allow_other" "iam_role" ];
+    };
+    environment.systemPackages = [ pkgs.s3fs ];
+  };
+  resources = {
+    s3Buckets = {
+      # if moved to another region, you must rename the bucket
+      report-bucket-3 = { config, uuid, ... }: {
+        region = "ap-northeast-1";
+        accessKeyId = IOHKaccessKeyId;
+      };
+    };
+    iamRoles = {
+      report-role = { config, uuid, ...}: {
+        accessKeyId = IOHKaccessKeyId;
+        assumeRolePolicy = builtins.toJSON {
+          Version = "2008-10-17";
+          Statement = [
+            {
+              Action = "sts:AssumeRole";
+              Effect = "Allow";
+              Principal = {
+                Service = "ec2.amazonaws.com";
+                # allows main IOHK account to assume-role for testing
+                AWS = "arn:aws:iam::741691143009:root";
+              };
+            }
+          ];
+        };
+        policy = builtins.toJSON {
+          Version = "2012-10-17";
+          Statement = [
+            {
+              Effect = "Allow";
+              Action = "s3:*";
+              Resource = "arn:aws:s3:::charon-${uuid}-report-bucket-3";
+            }
+            {
+              Effect = "Allow";
+              Action = "s3:*";
+              Resource = "arn:aws:s3:::charon-${uuid}-report-bucket-3/*";
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/deployments/report-server-bucket-storage.nix
+++ b/deployments/report-server-bucket-storage.nix
@@ -18,7 +18,7 @@
     s3Buckets = {
       # if moved to another region, you must rename the bucket
       report-server-logs = { config, uuid, ... }: {
-        region = "ap-northeast-1";
+        region = "eu-central-1";
         accessKeyId = IOHKaccessKeyId;
       };
     };

--- a/deployments/report-server-bucket-storage.nix
+++ b/deployments/report-server-bucket-storage.nix
@@ -8,7 +8,7 @@
     deployment.ec2.instanceProfile = resources.iamRoles.report-role.name;
     fileSystems."/var/lib/report-server" = {
       # mount unsets PATH when running this
-      device = "/run/current-system/sw/bin/s3fs#${resources.s3Buckets.report-bucket-3.name}";
+      device = "/run/current-system/sw/bin/s3fs#${resources.s3Buckets.report-server-logs.name}";
       fsType = "fuse";
       options = [ "_netdev" "allow_other" "iam_role" ];
     };
@@ -17,7 +17,7 @@
   resources = {
     s3Buckets = {
       # if moved to another region, you must rename the bucket
-      report-bucket-3 = { config, uuid, ... }: {
+      report-server-logs = { config, uuid, ... }: {
         region = "ap-northeast-1";
         accessKeyId = IOHKaccessKeyId;
       };
@@ -45,12 +45,12 @@
             {
               Effect = "Allow";
               Action = "s3:*";
-              Resource = "arn:aws:s3:::charon-${uuid}-report-bucket-3";
+              Resource = "arn:aws:s3:::charon-${uuid}-report-server-logs";
             }
             {
               Effect = "Allow";
               Action = "s3:*";
-              Resource = "arn:aws:s3:::charon-${uuid}-report-bucket-3/*";
+              Resource = "arn:aws:s3:::charon-${uuid}-report-server-logs/*";
             }
           ];
         };

--- a/deployments/report-server-env-production.nix
+++ b/deployments/report-server-env-production.nix
@@ -2,6 +2,7 @@
 let nodeMap = { inherit (globals.fullMap) report-server; }; in
 
 {
+  require = [ ./report-server-bucket-storage.nix ];
   report-server = { resources, ...}: {
     imports = [
       ./../modules/production.nix

--- a/deployments/report-server-env-staging.nix
+++ b/deployments/report-server-env-staging.nix
@@ -2,6 +2,7 @@
 let nodeMap = { inherit (globals.fullMap) report-server; }; in
 
 {
+  require = [ ./report-server-bucket-storage.nix ];
   report-server = { config, resources, ...}: {
     imports = [
       ./../modules/staging.nix

--- a/deployments/report-server.nix
+++ b/deployments/report-server.nix
@@ -1,7 +1,6 @@
-{ globals, ... }: with (import ./../lib.nix);
-let nodeMap = { inherit (globals.fullMap) report-server; }; in
+{ globals, ... }:
 
-flip mapAttrs nodeMap
-(name: import ./../modules/report-server.nix
-       globals
-       [])
+{
+  require = [ ./report-server-bucket-storage.nix ];
+  report-server = import ./../modules/report-server.nix globals.fullMap.report-server;
+}

--- a/deployments/report-server.nix
+++ b/deployments/report-server.nix
@@ -1,6 +1,5 @@
 { globals, ... }:
 
 {
-  require = [ ./report-server-bucket-storage.nix ];
   report-server = import ./../modules/report-server.nix globals.fullMap.report-server;
 }

--- a/globals.nix
+++ b/globals.nix
@@ -74,7 +74,7 @@ let topologySpec     = builtins.fromJSON (builtins.readFile topologyFile);
     relays          = filter     (x: x.value.typeIsRelay)             indexed;
     nodeMap         = listToAttrs (cores ++ relays);
     # WARNING: this depends on the sort order, as explained above.
-    firstRelay      = findFirst (x: x.value.typeIsRelay) (throw "No relays in topology, it's sad we can't live, but then.. who does?") indexed;
+    firstRelay      = findFirst (x: x.value.typeIsRelay) ({ name = "fake-non-relay"; value = { type = "relay"; i = builtins.length indexed; }; }) indexed;
     firstRelayIndex = firstRelay.value.i;
     nRelays         = length relays;
     ## Fuller map to include "other" nodes:

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -78,7 +78,6 @@ data Command where
   -- * setup
   Clone                 :: { cBranch      :: Branch } -> Command
   Template              :: { tFile        :: Maybe Turtle.FilePath
-                           , tNixops      :: Maybe Turtle.FilePath
                            , tTopology    :: Maybe Turtle.FilePath
                            , tConfigurationKey :: Maybe ConfigurationKey
                            , tEnvironment :: Environment
@@ -128,7 +127,6 @@ centralCommandParser =
     , ("template",              "Produce (or update) a checkout of BRANCH with a cluster config YAML file (whose default name depends on the ENVIRONMENT), primed for future operations.",
                                 Template
                                 <$> optional (optPath "config"        'c' "Override the default, environment-dependent config filename")
-                                <*> optional (optPath "nixops"        'n' "Use a specific Nixops binary for this cluster")
                                 <*> optional (optPath "topology"      't' "Cluster configuration.  Defaults to 'topology.yaml'")
                                 <*> optional parserConfigurationKey
                                 <*> parserEnvironment
@@ -285,8 +283,7 @@ runTemplate o@Options{..} Template{..} args = do
 
   systemStart <- timeCurrent
   let cmdline = T.concat $ intersperse " " $ fromArg <$> args
-  nixops <- (<> "/bin/nixops") . T.strip <$> incmd o "nix-build" ["-A", "nixops"]
-  config <- Ops.mkNewConfig o cmdline tName (tNixops <|> (Path.fromText <$> Just nixops)) tTopology tEnvironment tTarget tDeployments systemStart tConfigurationKey
+  config <- Ops.mkNewConfig o cmdline tName tTopology tEnvironment tTarget tDeployments systemStart tConfigurationKey
   configFilename <- T.pack . Path.encodeString <$> Ops.writeConfig tFile config
 
   echo ""

--- a/modules/report-server.nix
+++ b/modules/report-server.nix
@@ -40,10 +40,13 @@ in {
     deployment.ec2.region         = mkForce params.region;
     deployment.ec2.accessKeyId    = params.accessKeyId;
     deployment.ec2.keyPair        = resources.ec2KeyPairs.${params.keyPairName};
-    deployment.ec2.securityGroups = optionals (! config.global.omitDetailedSecurityGroups)
-      (map (resolveSGName resources) [
-         "allow-to-report-server-${config.deployment.ec2.region}"
-       ]);
+    deployment.ec2.securityGroups =
+      let sgNames = [ "allow-to-report-server-${config.deployment.ec2.region}" ];
+      in map (resolveSGName resources)
+         (if config.global.omitDetailedSecurityGroups
+          then [ "allow-all-${params.region}-${params.org}" ]
+          else sgNames);
+
     deployment.ec2.ebsInitialRootDiskSize = 200;
 
     networking.firewall.allowedTCPPorts = [

--- a/modules/report-server.nix
+++ b/modules/report-server.nix
@@ -1,6 +1,6 @@
 with (import ./../lib.nix);
 
-globals: imports: params:
+params:
 { pkgs, config, resources, options, ...}:
 
 let
@@ -66,6 +66,7 @@ in {
       description   = "Cardano report server";
       after         = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+      unitConfig.RequiresMountsFor = cfg.logsdir;
       serviceConfig = {
         User = "report-server";
         Group = "report-server";

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -4,8 +4,6 @@ set -xeu
 
 source ./scripts/set_nixpath.sh
 
-NIXOPS=$(nix-build -A nixops)/bin/nixops
-
 IOHK_OPS=${1:-$(nix-build -A iohk-ops)/bin/iohk-ops}
 CLEANUP_DEPLOYS=${2:-true}
 CLEANUP_CONFIGS=${3:-true}
@@ -34,7 +32,6 @@ done
 
 
 # 0. Check all scripts compile
-${NIXOPS} --version
 nix-shell --run "./scripts/aws.hs --help"
 ${IOHK_OPS} --help
 
@@ -60,7 +57,7 @@ banner() {
 }
 
 GENERAL_OPTIONS="--verbose --deployer 0.0.0.0"
-COMMON_OPTIONS="--nixops ${NIXOPS} --topology topology-min.yaml"
+COMMON_OPTIONS="--topology topology-min.yaml"
 CARDANO_COMPONENTS="Nodes ${WITH_EXPLORER:+Explorer} ${WITH_REPORT_SERVER:+ReportServer}"
 
 if test -n "${WITH_STAGING}"; then

--- a/topology-mainnet-infra.yaml
+++ b/topology-mainnet-infra.yaml
@@ -1,8 +1,0 @@
-nodes:
-  'mainnet-deployer':
-    type: relay
-    region: eu-central-1
-    static-routes: [['mainnet-deployer']]
-    host: mainnet-deployer.cardano
-    port: 3000
-    org: IOHK


### PR DESCRIPTION
currently, its enabled for both mainnet and staging, but it can easily be adjusted to target just one

due to boto2 in nixops, the bucket must be in a region that supports auth method version 2
the report-server ec2 is currently in frankfurt, so latency to the bucket may be high
