### PR TITLE
[DEVOPS-157]  iohk-ops clone:  specify the destination directory

### DIFF
--- a/iohk/Constants.hs
+++ b/iohk/Constants.hs
@@ -22,6 +22,8 @@ defaultNode          = NodeName "c-a-1"
 defaultNodePort      = PortNo 3000
 defaultNixpkgs       = Nothing
 
+defaultIOPSBranch    = Branch "develop"
+
 defaultHold          = 1200 :: Seconds -- 20 minutes
 
 explorerNode         = NodeName "explorer"


### PR DESCRIPTION
This PR supports the final work for the upcoming developer cluster documentation (at https://github.com/input-output-hk/internal-documentation/wiki/Developer-clusters-HOWTO):

- `iohk-ops clone <CHECKOUT-NAME> [<IOHK-OPS-BRANCH>]`