### PR TITLE
[DEVOPS-497] no update step3

### DIFF
--- a/scripts/update-script-3.sh
+++ b/scripts/update-script-3.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# ran to vote for the proposal
-
-source config
-
-for idx in {1..4}; do
-  ./auxx/bin/cardano-auxx $COMMONOPTS $AUXXOPTS cmd --commands "vote ${idx} y ${PROPOSAL_ID}"
-done


### PR DESCRIPTION
Drop the third update script, since its action is now subsumed by the `vote-all` command in the second script.