### PR TITLE
[DEVOPS-623]  ci:  trace cleanup

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -49,7 +49,7 @@ cleanup() {
         for depl in ${CLEANUP_DEPLS}
         do
                 test -z "${CLEANUP_DEPLOYS}" ||
-                        ${IOHK_OPS} --config ${depl}'.yaml' destroy delete >/dev/null 2>&1
+                        ${IOHK_OPS} --config ${depl}'.yaml' destroy delete
                 test -z "${CLEANUP_CONFIGS}" ||
                         rm -f                ${depl}'.yaml'
         done


### PR DESCRIPTION
This is to re-enable logging of Nixops state cleanup, in context of DEVOPS-623 debugging.