### PR TITLE
[DEVOPS-607] Disallow non-root set authorized_keys on all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Collection of tooling and automation to deploy IOHK infrastructure.
 
 ### Getting SSH access
 
-Append https://github.com/input-output-hk/pos-prototype-deployment/blob/master/lib.nix#L46 and submit a PR.
+Append https://github.com/input-output-hk/iohk-ops/blob/master/lib.nix#L83 and submit a PR.

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -17,6 +17,9 @@ in {
 
   services.openssh.passwordAuthentication = false;
   services.openssh.enable = true;
+  # Non-root users are not allowed to install authorized keys.
+  services.openssh.authorizedKeysFiles = pkgs.lib.mkForce
+    [ "/etc/ssh/authorized_keys.d/%u" ];
 
   services.ntp.enable = true;
 


### PR DESCRIPTION
Have not been able to test this in a new developer cluster yet.
However there is a good chance it will work because the same config change worked in another NixOS setup.