### PR TITLE
allow root to use ~/.ssh/authorized_keys

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 with (import ./../lib.nix);
 
@@ -20,6 +20,10 @@ in {
   # Non-root users are not allowed to install authorized keys.
   services.openssh.authorizedKeysFiles = pkgs.lib.mkForce
     [ "/etc/ssh/authorized_keys.d/%u" ];
+  services.openssh.extraConfig = lib.mkOrder 999 ''
+    Match User root
+        AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys2 /etc/ssh/authorized_keys.d/%u
+  '';
 
   services.ntp.enable = true;
 


### PR DESCRIPTION
nixops doesnt add its own keys to the nixos config, and assumes that the `~/.ssh/authorized_keys` setup by aws will remain in effect