### PR TITLE
[DEVOPS-645]  iohk-ops:  update to the new cardano-keygen

### DIFF
--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -330,8 +330,8 @@ runNew o@Options{..} New{..} args = do
     else do
       generateStakeKeys o (clusterConfigurationKey config) "keys"
       sh $ do
-        k <- Turtle.find ((prefix "keys/keys-testnet/rich/key") <> (suffix ".sk"))
-          "keys/keys-testnet/rich"
+        k <- Turtle.find ((prefix "keys/generated-keys/rich/key") <> (suffix ".sk"))
+          "keys/generated-keys/rich"
         cp k $ "keys" </> Path.filename k
   echo "Cluster deployment has been prepared."
 


### PR DESCRIPTION
This fixes DEVOPS-645:
```
nix-shell:~/testing-jumps]$ io new testing-jumps nodes

-- config.yaml is:
args:
  configurationKey:
    tag: NixStr
    contents: devnet
  EmurgoaccessKeyId:
    tag: NixStr
    contents: cardano-deployer
  systemStart:
    tag: NixInt
    contents: 1517408907
  CFaccessKeyId:
    tag: NixStr
    contents: cardano-deployer
  IOHKaccessKeyId:
    tag: NixStr
    contents: cardano-deployer
gen-cmdline: new testing-jumps nodes
environment: Development
installer-bucket: default-bucket
topology: topology-development.yaml
name: testing-jumps
files:
- deployments/cardano-nodes-env-development.nix
- deployments/keypairs.nix
- deployments/cardano-nodes.nix
elements:
- Nodes
target: AWS
INFO: using default.nix expression for its definition of 'nixops'
INFO: nixops is /nix/store/kc5iq1za2qp1qrpkdc15z7qgxibms1i0-nixops-1.6pre0_abcdef/bin/nixops
Creating deployment testing-jumps
created deployment ‘04557651-0693-11e8-b960-06de07e93aea’
04557651-0693-11e8-b960-06de07e93aea
Ensured secrets exist
[keygen:INFO] [2018-01-31 14:28:34.71 UTC] using configurations: ConfigurationOptions {cfoFilePath = "/nix/store/hdv0xrv0bycpcdjcs8anwmcdc3s15gg4-cardano-sl-c3ba8aa/lib/configuration.yaml", cfoKey = "devnet", cfoSystemStart = Just 0, cfoSeed = Nothing}
[keygen:INFO] [2018-01-31 14:28:35.05 UTC] withConfiguration using custom system start time 0
[keygen:INFO] [2018-01-31 14:28:35.05 UTC] We are going to generate genesis data from genesis spec, it can take a lot of time if there are many HD addresses!
[keygen:INFO] [2018-01-31 14:28:35.05 UTC] Processing command
[keygen:INFO] [2018-01-31 14:28:35.05 UTC] Dumping generated genesis secrets into keys/generated-keys
^[[O3Q[keygen:INFO] [2018-01-31 14:28:44.36 UTC] 206 keyfiles are generated
[keygen:INFO] [2018-01-31 14:28:44.36 UTC] Generating fake avvm data into keys/keys-fakeavvm
[keygen:INFO] [2018-01-31 14:28:44.37 UTC] 100 fake avvm seeds are generated
[keygen:INFO] [2018-01-31 14:28:44.37 UTC] keys generated successfully
iohk-ops: keys/keys-testnet/rich: fileAccess: does not exist (No such file or directory)
```