### PR TITLE
[DEVOPS-666] find-installers: fix logic for getting cardano revision

### DIFF
--- a/iohk/default.nix
+++ b/iohk/default.nix
@@ -3,9 +3,9 @@
 , directory, dns, errors, git, hourglass, hspec, http-client
 , http-client-tls, http-conduit, http-types, lens, lens-aeson
 , managed, memory, mtl, network-uri, optional-args
-, optparse-applicative, resourcet, safe, stdenv, system-filepath
-, text, turtle, universum, unix, unordered-containers, utf8-string
-, vector, yaml
+, optparse-applicative, regex-pcre, resourcet, safe, stdenv
+, system-filepath, text, turtle, universum, unix
+, unordered-containers, utf8-string, vector, yaml
 }:
 mkDerivation {
   pname = "iohk-ops";
@@ -18,15 +18,15 @@ mkDerivation {
     bytestring cassava containers cryptonite directory dns errors git
     hourglass http-client http-client-tls http-conduit http-types lens
     lens-aeson managed memory mtl network-uri optional-args
-    optparse-applicative resourcet safe system-filepath text turtle
-    unix unordered-containers utf8-string vector yaml
+    optparse-applicative regex-pcre resourcet safe system-filepath text
+    turtle unix unordered-containers utf8-string vector yaml
   ];
   testHaskellDepends = [
     aeson amazonka amazonka-s3 ansi-terminal base bytestring cassava
     cryptonite directory errors git hspec http-client http-client-tls
-    http-conduit http-types lens managed memory network-uri resourcet
-    safe system-filepath text turtle universum unordered-containers
-    yaml
+    http-conduit http-types lens managed memory network-uri regex-pcre
+    resourcet safe system-filepath text turtle universum
+    unordered-containers yaml
   ];
   license = stdenv.lib.licenses.bsd3;
 }

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -37,6 +37,7 @@ executable iohk-ops
                      , mtl >=2.2
                      , network-uri
                      , optional-args
+                     , regex-pcre >= 0.94
                      , safe >=0.3
                      , system-filepath >=0.4
                      , text >=1.2
@@ -94,4 +95,5 @@ test-suite iohk-ops-test
                   , cryptonite
                   , errors
                   , memory
+                  , regex-pcre
   hs-source-dirs:   test .

--- a/iohk/test/UpdateLogicSpec.hs
+++ b/iohk/test/UpdateLogicSpec.hs
@@ -19,7 +19,7 @@ spec :: Spec
 spec = do
   describe "travis log output" $ do
     it "tests travis log output parsing" $ do
-      extractBuildId sampleInput `shouldBe` 13711
+      extractBuildId sampleInput `shouldBe` Just 13711
 
   describe "GitHub commit status parsing" $ do
     it "recognizes a buildkite status entry" $


### PR DESCRIPTION
It gets the cardano revision from the buildkite cardano build.

Due to my mistake in #240 (DEVOPS-606), it was getting the most recent buildkite cardano build, rather than the one referred to in the build logs.
