### PR TITLE
[DEVOPS-683] report-server: Different Zendesk account for staging

### DIFF
--- a/deployments/report-server-env-production.nix
+++ b/deployments/report-server-env-production.nix
@@ -11,6 +11,7 @@ let nodeMap = { inherit (globals.fullMap) report-server; }; in
     ];
 
     config.services.report-server.zendesk = {
+      accountName = "iohk";
       email = "daedalus-bug-reports@iohk.io";
       tokenFile = "/run/keys/zendesk-token";
     };

--- a/deployments/report-server-env-staging.nix
+++ b/deployments/report-server-env-staging.nix
@@ -11,7 +11,8 @@ let nodeMap = { inherit (globals.fullMap) report-server; }; in
     ];
 
     config.services.report-server.zendesk = {
-      email = "daedalus-bug-reports@iohk.io";
+      accountName = "iohksupport";  # NB. expires on 2018-02-26
+      email = "staging-report-server@iohk.io";
       tokenFile = "/run/keys/zendesk-token";
     };
   };

--- a/modules/report-server.nix
+++ b/modules/report-server.nix
@@ -43,6 +43,14 @@ in {
             An access token for Zendesk.
           '';
         };
+        accountName = mkOption {
+          type = types.str;
+          default = "";
+          example = "iohk";
+          description = ''
+            Zendesk account name. This is the first part of NAME.zendesk.com.
+          '';
+        };
       };
     };
   };
@@ -99,7 +107,7 @@ in {
         zdEmail = if cfg.zendesk.email != "" then "--zd-email \"${cfg.zendesk.email}\"" else "";
         # fixme: report-server should not accept token as command-line argument
         zdToken = if cfg.zendesk.tokenFile != null then "--zd-token `head -1 ${cfg.zendesk.tokenFile}`" else "";
-        zdAccount = if cfg.zendesk.tokenFile != null then "--zd-account iohk" else "";
+        zdAccount = if cfg.zendesk.accountName != "" then "--zd-account \"${cfg.zendesk.accountName}\"" else "";
       in ''
         exec ${cfg.executable}/bin/cardano-report-server \
             -p ${toString cfg.port} \
@@ -110,11 +118,12 @@ in {
 
     assertions = [
       { assertion =
-          (cfg.zendesk.email != "" && cfg.zendesk.tokenFile != null) ||
-          (cfg.zendesk.email == "" && cfg.zendesk.tokenFile == null);
+          (cfg.zendesk.email != "" && cfg.zendesk.tokenFile != null && cfg.zendesk.accountName != "") ||
+          (cfg.zendesk.email == "" && cfg.zendesk.tokenFile == null && cfg.zendesk.accountName == "");
         message = ''
-          Both `services.report-server.zendesk.email'
-          and `services.report-server.zendesk.tokenFile' must be defined.
+          Either all or none of `services.report-server.zendesk.email',
+          `services.report-server.zendesk.tokenFile',
+          `services.report-server.zendesk.accountName' must be defined.
         '';
       }
     ];


### PR DESCRIPTION
We have an `iohksupport.zendesk.com` account which will expire in 6 days.

Have tested this change in development cluster, with `report-server.zendesk` options temporarily enabled in that environment.
