### PR TITLE
[DEVOPS-687]  DD | disk_hydra: warning vs. critical threshold

### DIFF
--- a/deployments/infrastructure-target-aws.nix
+++ b/deployments/infrastructure-target-aws.nix
@@ -82,7 +82,7 @@ in rec {
     };
     datadogMonitors = (with (import ./../modules/datadog-monitors.nix); {
       disk       = mkMonitor (disk_monitor "!group:hydra-and-slaves" "0.8"  "0.9");
-      disk_hydra = mkMonitor (disk_monitor  "group:hydra-and-slaves" "0.95" "0.95");
+      disk_hydra = mkMonitor (disk_monitor  "group:hydra-and-slaves" "0.95" "0.951");
       ntp  = mkMonitor ntp_monitor;
     });
   };


### PR DESCRIPTION
Fix a minor threshold issue:
```
Traceback (most recent call last):
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/bin/.nixops-wrapped", line 984, in <module>
    args.op()
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/bin/.nixops-wrapped", line 407, in op_deploy
    max_concurrent_activate=args.max_concurrent_activate)
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1044, in deploy
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1033, in run_with_notify
    f()
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1044, in <lambda>
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 977, in _deploy
    nixops.parallel.run_tasks(nr_workers=-1, tasks=self.active_resources.itervalues(), worker_fun=worker)
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/parallel.py", line 44, in thread_fun
    result_queue.put((worker_fun(t), None, t.name))
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 950, in worker
    r.create(self.definitions[r.name], check=check, allow_reboot=allow_reboot, allow_recreate=allow_recreate)
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/resources/datadog-monitor.py", line 96, in create
    monitor_id = self.create_monitor(defn=defn, options=options)
  File "/nix/store/wm0jd92gb5vflky0bhkal5v9hvg4ap6a-nixops-1.6pre0_abcdef/lib/python2.7/site-packages/nixops/resources/datadog-monitor.py", line 76, in create_monitor
    raise Exception(str(response['errors']))
Exception: ['Warning threshold must be less than critical with > comparison']
```