### PR TITLE
jobsets: Add cardano-sl-1-1

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -102,6 +102,7 @@ let
   mainJobsets = with pkgs.lib; mapAttrs (name: settings: defaultSettings // settings) (rec {
     cardano-sl = mkCardano "master" nixpkgs-src.rev;
     cardano-sl-1-0 = mkCardano "cardano-sl-1.0" nixpkgs-src.rev;
+    cardano-sl-1-1 = mkCardano "release/1.1.0" nixpkgs-src.rev;
     daedalus = mkDaedalus "develop";
     iohk-nixops = mkNixops "master" nixpkgs-src.rev;
     iohk-nixops-staging = mkNixops "staging" nixpkgs-src.rev;


### PR DESCRIPTION
It would be good to have hydra building cardano-sl `release/1.1.0` branch so that it goes in the binary cache.

I haven't tested this change but it seems like it could work.

The [cardano-sl-1-0 jobset](https://hydra.iohk.io/jobset/serokell/cardano-sl-1-0#tabs-evaluations) doesn't seem to evaluate, possibly because the given branch doesn't exist in the repo.