### PR TITLE
re-arrange shell.nix to add new features and improve perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After cloning this repo, start a `nix-shell`.
 
 To hack on the `iohk-ops` tool, use
 
-    % nix-shell --arg io-dev-mode true
+    % nix-shell -A ioSelfBuild
     [nix-shell:~/iohk/iohk-ops]$ type io
     io is a function
     io ()

--- a/default.nix
+++ b/default.nix
@@ -25,14 +25,12 @@ let
     in (import "${nixopsUnstable}/release.nix" {
          nixpkgs = localLib.fetchNixPkgs;
         }).build.${system};
-  iohk-ops-extra-runtime-deps = [
-    pkgs.gitFull pkgs.nix-prefetch-scripts compiler.yaml
-    pkgs.wget
-    pkgs.file
-    cardano-sl-pkgs.cardano-sl-auxx
-    cardano-sl-pkgs.cardano-sl-tools
+  iohk-ops-extra-runtime-deps = with pkgs; [
+    gitFull nix-prefetch-scripts compiler.yaml
+    wget
+    file
     nixops
-    pkgs.terraform_0_11
+    terraform_0_11
   ];
   # we allow on purpose for cardano-sl to have it's own nixpkgs to avoid rebuilds
   cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);
@@ -49,6 +47,7 @@ in {
                 executableToolDepends = [ pkgs.makeWrapper ];
                 libraryHaskellDepends = iohk-ops-extra-runtime-deps;
                 postInstall = ''
+                  cp -vs $out/bin/iohk-ops $out/bin/io
                   wrapProgram $out/bin/iohk-ops \
                   --prefix PATH : "${pkgs.lib.makeBinPath iohk-ops-extra-runtime-deps}"
                 '';

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -65,6 +65,10 @@ GENERAL_OPTIONS="--verbose --deployer 0.0.0.0"
 COMMON_OPTIONS="--topology topology-min.yaml"
 CARDANO_COMPONENTS="Nodes ${WITH_EXPLORER:+Explorer} ${WITH_REPORT_SERVER:+ReportServer}"
 
+nix-build default.nix -A cardano-sl-tools -o cardano-sl-tools
+
+export PATH=$PATH:./cardano-sl-tools/bin/
+
 if test -n "${WITH_STAGING}"; then
 CLEANUP_DEPLS="${CLEANUP_DEPLS} test-stag"
 ${IOHK_OPS}               new  --config 'test-stag.yaml'   --environment staging    ${COMMON_OPTIONS} 'test-stag'    ${CARDANO_COMPONENTS}

--- a/shell.nix
+++ b/shell.nix
@@ -1,18 +1,31 @@
 { localLib ? import ./lib.nix
 , pkgs ? import (localLib.fetchNixPkgs) {}
-, io-dev-mode ? false
 }:
 
 let
-  iohk-ops = (import ./default.nix {}).iohk-ops;
-  ioAlias  = if io-dev-mode
-             then ''runhaskell -iiohk iohk/iohk-ops.hs''
-             else ''${iohk-ops}/bin/iohk-ops'';
-in pkgs.lib.overrideDerivation iohk-ops.env
-   (old: {
-     shellHook = ''
-       function io {
-        ${ioAlias} "$@"
-       }
-     '';
-    })
+  iohkpkgs = import ./default.nix {};
+  iohk-ops = iohkpkgs.iohk-ops;
+  justIo = pkgs.runCommand "shell" {
+    buildInputs = with pkgs; [ iohk-ops terraform_0_11 nixops ];
+    passthru = {
+      inherit ioSelfBuild withAuxx;
+    };
+  } "echo use nix-shell";
+  ioSelfBuild = pkgs.lib.overrideDerivation iohk-ops.env (drv: {
+    shellHook = ''
+      function io {
+        runhaskell -iiohk iohk/iohk-ops.hs
+      }
+      function ghcid-io {
+        ${pkgs.haskellPackages.ghcid}/bin/ghcid -c "ghci -iiohk iohk/iohk-ops.hs"
+      }
+    '';
+  });
+  withAuxx = pkgs.runCommand "shell" {
+    buildInputs = [
+      iohk-ops
+      iohkpkgs.cardano-sl-auxx
+      iohkpkgs.cardano-sl-tools
+    ];
+  } "echo use nix-shell";
+in justIo


### PR DESCRIPTION
plain `nix-shell` gives you a shell with just `io`, `nixops`,and `terraform` and no cardano or ghc
`nix-shell -A ioSelfBuild` gives you a shell with `io` and `ghcid-io` functions and a ghc that can build iohk-ops
`nix-shell -A withAuxx` gives a shell with io, auxx, and tools, no ghc