### PR TITLE
[DEVOPS-674] buildkite darwin: run git clean before build

### DIFF
--- a/nix-darwin/buildkite-agent-module.nix
+++ b/nix-darwin/buildkite-agent-module.nix
@@ -36,6 +36,7 @@ in {
       export PATH=\$PATH:/usr/bin:/usr/sbin
     '';
     extraConfig = ''
+      git-clean-flags=-fdxq
       # debug=true
       # priority=9
     '';


### PR DESCRIPTION
I would like to do the same change for the linux buildkite-agents, but the `services.buildkite-agent.extraConfig` option isn't implemented in 17.09.

This is an initial step towards more build purity and will help in the short-term with disk space shortages.
