### PR TITLE
[PB-12] --no-ntp removed

### DIFF
--- a/modules/cardano-service.nix
+++ b/modules/cardano-service.nix
@@ -23,7 +23,6 @@ let
     #"+RTS -N -pa -hb -T -A6G -qg -RTS"
     # Event logging (cannot be used with profiling)
     #"+RTS -N -T -l -A6G -qg -RTS"
-    "--no-ntp" # DEVOPS-160
     (optionalString cfg.stats "--stats")
     (optionalString (!cfg.productionMode) "--rebuild-db")
     (optionalString (!cfg.productionMode) "--spending-genesis ${toString cfg.nodeIndex}")
@@ -79,7 +78,7 @@ in {
       autoStart = mkOption { type = types.bool; default = true; };
 
       topologyYaml = mkOption { type = types.path; };
-      
+
       genesisN = mkOption { type = types.int; default = 6; };
       slotDuration = mkOption { type = types.int; default = 20; };
       networkDiameter = mkOption { type = types.int; default = 15; };


### PR DESCRIPTION
If you try to deploy a cluster on cardano-sl develop branch, the nodes won't start.

This is because the `--no-ntp` switch was removed.

 - https://github.com/input-output-hk/cardano-sl/pull/2716
 - https://github.com/input-output-hk/cardano-sl/commit/9ff4a9d40d246667cac84318f970e4523cef0e8c
