### PR TITLE
[DEVOPS-709] Fix iohk-ops set-version-json and add sha256 hashes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,7 @@ let
     file
     nixops
     terraform
+    coreutils
   ];
   terraform = pkgs.terraform_0_11.withPlugins (ps: [ ps.aws ]);
   # we allow on purpose for cardano-sl to have it's own nixpkgs to avoid rebuilds

--- a/iohk/Appveyor.hs
+++ b/iohk/Appveyor.hs
@@ -20,7 +20,7 @@ import           Types           (ApplicationVersion(ApplicationVersion), Arch(W
 import           Data.Coerce                      (coerce)
 
 newtype JobId = JobId T.Text deriving (Show, Eq, Monoid)
-newtype BuildNumber = BuildNumber Integer deriving (Show, Eq)
+newtype BuildNumber = BuildNumber Int deriving (Show, Eq)
 newtype Username = Username { usernameToText :: T.Text } deriving (Show, Eq, Monoid, IsString)
 newtype Project = Project { projectToText :: T.Text } deriving (Show, Eq, Monoid, IsString)
 

--- a/iohk/Cardano.hs
+++ b/iohk/Cardano.hs
@@ -15,7 +15,7 @@ data ConfigurationRoot = ConfigurationRoot {
   } deriving (Show, Generic, Eq)
 
 data ConfigurationUpdate = ConfigurationUpdate {
-    applicationVersion :: Integer
+    applicationVersion :: Int
   } deriving (Show, Generic, Eq)
 
 instance FromJSON ConfigurationRoot

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -52,6 +52,7 @@ module NixOps (
   , parallelIO
   , nixopsConfigurationKey
   , configurationKeys
+  , getCardanoSLSource
 
   -- * Types
   , Arg(..)
@@ -802,6 +803,12 @@ build :: Options -> NixopsConfig -> Deployment -> IO ()
 build o _c depl = do
   echo "Building derivation..."
   cmd o "nix-build" ["--max-jobs", "4", "--cores", "2", "-A", fromAttr $ deploymentBuildTarget depl]
+
+
+-- | Use nix to grab the sources of cardano-sl.
+getCardanoSLSource :: Options -> IO Path.FilePath
+getCardanoSLSource o = parent . fromText <$> incmdStrip o "nix-instantiate" args
+  where args = [ "--eval", "-A", "cardano-sl.src", "default.nix" ]
 
 
 -- * State management

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -913,7 +913,7 @@ s3Upload :: T.Text -> NixopsConfig -> IO ()
 s3Upload daedalus_rev c = do
   let
     say = liftIO . TIO.putStrLn
-    uploadOneFile :: BucketName -> T.Text -> ObjectKey -> Integer -> T.Text -> AWST (ResourceT IO) ()
+    uploadOneFile :: BucketName -> T.Text -> ObjectKey -> Int -> T.Text -> AWST (ResourceT IO) ()
     uploadOneFile bucketName localPath remoteKey appver cardanoCommit = do
       bdy <- chunkedFile defaultChunkSize (T.unpack localPath)
       let
@@ -926,7 +926,7 @@ s3Upload daedalus_rev c = do
       void . send $ Lens.set poACL (Just OPublicRead) $ Lens.set poMetadata newMetaData $ putObject bucketName remoteKey bdy
     copyObject' :: BucketName -> T.Text -> ObjectKey -> AWST (ResourceT IO) ()
     copyObject' bucketName source dest = void . send $ Lens.set coACL (Just OPublicRead) $ copyObject bucketName source dest
-    uploadHashedInstaller :: T.Text -> T.Text -> Integer -> T.Text -> AWST (ResourceT IO) (T.Text, T.Text)
+    uploadHashedInstaller :: T.Text -> T.Text -> Int -> T.Text -> AWST (ResourceT IO) (T.Text, T.Text)
     uploadHashedInstaller bucketName localPath appver cardanoCommit = do
       hash <- (liftIO . hashInstaller) localPath
       let
@@ -937,7 +937,7 @@ s3Upload daedalus_rev c = do
         uploadOneFile (BucketName bucketName) localPath (ObjectKey hash) appver cardanoCommit
         copyObject' (BucketName bucketName) (bucketName <> "/" <> hash) (ObjectKey basename')
       return (hash, s3Link (toText region) bucketName basename')
-    hashAndUpload :: Integer -> T.Text -> CiResult -> AWST (ResourceT IO) ()
+    hashAndUpload :: Int -> T.Text -> CiResult -> AWST (ResourceT IO) ()
     hashAndUpload appver cardanoCommit ciResult = do
       let path = resultLocalPath ciResult
       (hash, url) <- uploadHashedInstaller (cUpdateBucket c) path appver cardanoCommit

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -36,7 +36,6 @@ module NixOps (
   , NixOps.date
   , s3Upload
   , findInstallers
-  , setVersionJson
 
   , awsPublicIPURL
   , defaultEnvironment
@@ -942,12 +941,6 @@ findInstallers daedalus_rev c = do
   with (realFindInstallers daedalus_rev (configurationKeys $ cEnvironment c)) $ \res -> do
     print res
     TIO.putStrLn $ githubWikiRecord res
-
-setVersionJson :: T.Text -> NixopsConfig -> IO ()
-setVersionJson daedalus_rev c = do
-  with (realFindInstallers daedalus_rev (configurationKeys $ cEnvironment c)) $ \res -> do
-    print res
-    updateVersionJson res (cUpdateBucket c)
 
 wipeJournals :: Options -> NixopsConfig -> IO ()
 wipeJournals o c@NixopsConfig{..} = do

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -118,7 +118,7 @@ data CiResult = AppveyorResult
 data GlobalResults = GlobalResults {
       grCardanoCommit      :: T.Text
     , grDaedalusCommit     :: T.Text
-    , grApplicationVersion :: Integer
+    , grApplicationVersion :: Int
   } deriving Show
 data InstallersResults = InstallersResults
   { appveyorResult  :: Maybe CiResult
@@ -349,7 +349,7 @@ printDarwinBuildInfo ci cardanoBuildNumber cardanoRev url = do
 -- | Gets version information from the config files in the cardano-sl git repo.
 grabAppVersion :: T.Text     -- ^ git commit id to check out
                -> (ApplicationVersionKey 'Win64, ApplicationVersionKey 'Mac64) -- ^ yaml keys to find
-               -> IO Integer -- ^ an integer version, not sure really
+               -> IO Int     -- ^ an integer version, not sure really
 grabAppVersion rev (winKey, macosKey) = do
     let
       readPath name = readFileFromGit rev name "cardano" "https://github.com/input-output-hk/cardano-sl"

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -15,7 +15,6 @@ module UpdateLogic
   , githubWikiRecord
   , InstallersResults(..)
   , GlobalResults(..)
-  , updateVersionJson
   , updateVersionJsonS3
   , extractBuildId
   , parseStatusContext
@@ -134,14 +133,6 @@ data InstallersResults = InstallersResults
   } deriving (Show, Generic)
 type TextPath = T.Text
 type RepoUrl = T.Text
-
-data VersionJson = VersionJson {
-      _linux :: ApplicationVersion 'Linux64
-    , _macos :: ApplicationVersion 'Mac64
-    , _win64 :: ApplicationVersion 'Win64
-  } deriving (Show, Generic)
-
-instance ToJSON VersionJson
 
 -- | Get VERSION environment variable from pipeline definition.
 -- First looks in global env, otherwise finds first build step with a version.
@@ -482,14 +473,6 @@ githubWikiRecord results = join [ T.pack $ show appVersion
     ciLink Nothing = "*missing*"
 
     join = T.intercalate " | "
-
-updateVersionJson :: InstallersResults -> T.Text -> IO ()
-updateVersionJson info bucket = do
-  let
-    macVersion = bkVersion <$> buildkiteResult info
-    winVersion = avVersion <$> appveyorResult info
-    json = encode $ VersionJson "" (fromMaybe "" macVersion) (fromMaybe "" winVersion)
-  void $ updateVersionJsonS3 bucket json
 
 updateVersionJsonS3 :: T.Text -> LBS.ByteString -> IO T.Text
 updateVersionJsonS3 bucket json = runAWS' $ do

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -10,6 +10,9 @@
 module UpdateLogic
   ( realFindInstallers
   , CiResult(..)
+  , ciResultLocalPath
+  , ciResultVersion
+  , ciResultUrl
   , hashInstaller
   , uploadHashedInstaller
   , githubWikiRecord
@@ -120,6 +123,18 @@ data CiResult = AppveyorResult
                 , bkUrl           :: T.Text
                 }
               deriving (Show, Generic)
+
+ciResultLocalPath :: CiResult -> T.Text
+ciResultLocalPath (AppveyorResult p _ _) = p
+ciResultLocalPath (BuildkiteResult p _ _ _ _) = p
+
+ciResultVersion :: CiResult -> T.Text
+ciResultVersion (AppveyorResult _ v _) = getApplicationVersion v
+ciResultVersion (BuildkiteResult _ v _ _ _) = getApplicationVersion v
+
+ciResultUrl :: CiResult -> T.Text
+ciResultUrl (AppveyorResult _ _ u) = u
+ciResultUrl (BuildkiteResult _ _ _ _ u) = u
 
 data GlobalResults = GlobalResults {
       grCardanoCommit      :: T.Text

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -468,7 +468,7 @@ githubWikiRecord results = join [ T.pack $ show appVersion
                                 , githubLink cardano_rev "cardano-sl"
                                 , ciLink buildkite
                                 , ciLink appvey
-                                , "DATE" ]
+                                , "DATE\n" ]
   where
     buildkiteDetails = buildkiteResult results
     appveyorDetails = appveyorResult results

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -261,7 +261,7 @@ runTop o@Options{..} args topcmd = do
             -- * High-level scenarios
             FromScratch              -> Ops.fromscratch               o c
             ReallocateCoreIPs        -> Ops.reallocateCoreIPs         o c
-            UpdateProposal up        -> updateProposal                c up
+            UpdateProposal up        -> updateProposal                o c up
             -- * live deployment ops
             DeployedCommit m         -> Ops.deployedCommit            o c m
             CheckStatus              -> Ops.checkstatus               o c

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -340,15 +340,10 @@ runNew _ _ _ = error "impossible"
 -- | Use 'cardano-keygen' to create keys for a develoment cluster.
 generateStakeKeys :: Options -> ConfigurationKey -> Turtle.FilePath -> IO ()
 generateStakeKeys o configurationKey outdir = do
-  -- XXX: compute cardano source path globally
-  configuration <- (<> "/configuration.yaml") <$> incmdStrip o "nix-instantiate"
-    [ "--eval"
-    , "-A", "cardano-sl.src"
-    , "default.nix"
-    ]
+  cardanoSrc <- getCardanoSLSource o
   cmd o "cardano-keygen"
     [ "--system-start", "0"
-    , "--configuration-file", configuration
+    , "--configuration-file", format (fp%"/lib/configuration.yaml") cardanoSrc
     , "--configuration-key", fromConfigurationKey configurationKey
     , "generate-keys-by-spec"
     , "--genesis-out-dir", T.pack $ Path.encodeString outdir

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -126,7 +126,6 @@ data Command where
   PrintDate             :: Command
   S3Upload              :: String -> Command
   FindInstallers        :: String -> Command
-  SetVersionJson       :: String -> Command
 deriving instance Show Command
 
 centralCommandParser :: Parser Command
@@ -210,8 +209,6 @@ centralCommandParser =
    , ("date",                   "Print date/time",                                                  pure PrintDate)
    , ("s3upload",               "test S3 upload",                                                   S3Upload <$> (strOption (long "daedalus-rev" <> short 'r' <> metavar "DAEDALUSREV"))  )
    , ("find-installers",        "find installers from CI",                                          FindInstallers <$> (strOption (long "daedalus-rev" <> short 'r' <> metavar "DAEDALUSREV")))
-   -- DEVOPS-709 - command temporarily removed
-   -- , ("set-version-json",       "set daedalus-latest-version.json to a given rev",                  SetVersionJson <$> (strOption (long "daedalus-rev" <> short 'r' <> metavar "DAEDALUSREV")))
    ]
 
    <|> subcommandGroup "Other:"
@@ -281,7 +278,6 @@ runTop o@Options{..} args topcmd = do
             PrintDate                -> Ops.date                      o c
             S3Upload               d -> Ops.s3Upload                  (T.pack d) c
             FindInstallers         d -> Ops.findInstallers            (T.pack d) c
-            SetVersionJson         d -> Ops.setVersionJson            (T.pack d) c
             Clone{..}                -> error "impossible"
             New{..}                  -> error "impossible"
             SetRev   _ _ _           -> error "impossible"

--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@ let
   ioSelfBuild = pkgs.lib.overrideDerivation iohk-ops.env (drv: {
     shellHook = ''
       function io {
-        runhaskell -iiohk iohk/iohk-ops.hs
+        runhaskell -iiohk iohk/iohk-ops.hs "$@"
       }
       function ghcid-io {
         ${pkgs.haskellPackages.ghcid}/bin/ghcid -c "ghci -iiohk iohk/iohk-ops.hs"


### PR DESCRIPTION
This adds more automation for the update-proposal script.

* The inputs to the process are now Daedalus revision, block version, voter index. The other values are looked up from various places.

* Adds find-installers, upload-s3 subcommands under update-proposal. These are used to populate the update proposal work dir with necessary info. The standalone versions of these remain.

* Adds set-version-json which matches the current website format but also includes SHA256 hashes.
