### PR TITLE
Hotfix: Sayonara `cardano-deployer`..

### DIFF
--- a/iohk/Constants.hs
+++ b/iohk/Constants.hs
@@ -124,6 +124,4 @@ envSettings env =
     Any -> error "envSettings called with 'Any'"
 
 selectDeployer :: Environment -> [Deployment] -> NodeName
-selectDeployer Staging   delts | elem Nodes delts = "iohk"
-                               | otherwise        = "cardano-deployer"
-selectDeployer _ _                                = "cardano-deployer"
+selectDeployer _ _ = "iohk"


### PR DESCRIPTION
1. Use `iohk` as the keypair for all of new deployments in `iohk-ops`.
2. Switch to `iohk` keypair for `hydra-build-slave-{1,2}`.  This is a proposal -- the exact discovery and solution are pending.