### PR TITLE
[DEVOPS-806] Update find-installers version scheme

### DIFF
--- a/iohk/Appveyor.hs
+++ b/iohk/Appveyor.hs
@@ -16,11 +16,10 @@ import           Data.String     (IsString)
 import qualified Data.Text       as T
 import           GHC.Generics    (Generic)
 import           Utils           (fetchJson)
-import           Types           (ApplicationVersion(ApplicationVersion), Arch(Win64))
-import           Data.Coerce                      (coerce)
+import           Types           (ApplicationVersion(ApplicationVersion, getApplicationVersion))
 
 newtype JobId = JobId T.Text deriving (Show, Eq, Monoid)
-newtype BuildNumber = BuildNumber Int deriving (Show, Eq)
+newtype BuildNumber = BuildNumber { unBuildNumber :: Int } deriving (Show, Eq)
 newtype Username = Username { usernameToText :: T.Text } deriving (Show, Eq, Monoid, IsString)
 newtype Project = Project { projectToText :: T.Text } deriving (Show, Eq, Monoid, IsString)
 
@@ -29,10 +28,10 @@ data ProjectBuildResults = ProjectBuildResults {
     } deriving (Show, Generic)
 
 data Build = Build {
-      _buildJobs         :: [ BuildJob ]
-    ,_buildBuildNumber :: BuildNumber
-    ,_buildVersion     :: ApplicationVersion 'Win64
-  } deriving (Show, Generic)
+      _buildJobs        :: [ BuildJob ]
+    , _buildBuildNumber :: BuildNumber
+    , _buildVersion     :: ApplicationVersion
+    } deriving (Show, Generic)
 
 data BuildJob = BuildJob {
       _buildJobJobId :: JobId
@@ -70,15 +69,15 @@ getArtifactUrl (JobId jobid) filename = "https://ci.appveyor.com/api/buildjobs/"
 -- input: "https://ci.appveyor.com/api/projects/jagajaga/daedalus/build/0.6.3356"
 -- /projects/{accountName}/{projectSlug}/build/{buildVersion}:
 -- from: https://github.com/kevinoid/appveyor-swagger/blob/master/swagger.yaml
-fetchAppveyorBuild :: Username -> Project -> ApplicationVersion 'Win64 -> IO ProjectBuildResults
-fetchAppveyorBuild user project version' = fetchJson $ "https://ci.appveyor.com/api/projects/" <> T.intercalate "/" [ usernameToText user, projectToText project, "build", coerce version' ]
+fetchAppveyorBuild :: Username -> Project -> ApplicationVersion -> IO ProjectBuildResults
+fetchAppveyorBuild user project version' = fetchJson $ "https://ci.appveyor.com/api/projects/" <> T.intercalate "/" [ usernameToText user, projectToText project, "build", getApplicationVersion version' ]
 
 fetchAppveyorArtifacts :: JobId -> IO [AppveyorArtifact]
 fetchAppveyorArtifacts (JobId jobid) = fetchJson $ "https://ci.appveyor.com/api/buildjobs/" <> jobid <> "/artifacts"
 
 -- input: https://ci.appveyor.com/project/jagajaga/daedalus/build/0.6.3356
 -- output:
-parseCiUrl :: T.Text -> (Username, Project, ApplicationVersion 'Win64)
+parseCiUrl :: T.Text -> (Username, Project, ApplicationVersion)
 parseCiUrl input = case T.splitOn "/" input of
   ["https:", "", "ci.appveyor.com", "project", username, project, "build", version'] -> (Username username, Project project, ApplicationVersion version')
   other -> error $ show other

--- a/iohk/Appveyor.hs
+++ b/iohk/Appveyor.hs
@@ -18,7 +18,7 @@ import           GHC.Generics    (Generic)
 import           Utils           (fetchJson)
 import           Types           (ApplicationVersion(ApplicationVersion, getApplicationVersion))
 
-newtype JobId = JobId T.Text deriving (Show, Eq, Monoid)
+newtype JobId = JobId { unJobId :: T.Text } deriving (Show, Eq, Monoid)
 newtype BuildNumber = BuildNumber { unBuildNumber :: Int } deriving (Show, Eq)
 newtype Username = Username { usernameToText :: T.Text } deriving (Show, Eq, Monoid, IsString)
 newtype Project = Project { projectToText :: T.Text } deriving (Show, Eq, Monoid, IsString)

--- a/iohk/InstallerVersions.hs
+++ b/iohk/InstallerVersions.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+
+module InstallerVersions
+  ( GlobalResults(..)
+  , findVersionInfo
+  , InstallerNetwork(..)
+  , installerNetwork
+  ) where
+
+
+import Prelude hiding (FilePath)
+
+import           Control.Lens hiding (strict)
+import           Data.Aeson (ToJSON, FromJSON)
+import           Data.Aeson.Lens
+import qualified Data.ByteString.Lazy.Char8   as S8
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict          as HM
+import qualified Data.Yaml                    as Y
+import qualified Filesystem.Path.CurrentOS    as FP
+import           GHC.Generics                 (Generic)
+import           Turtle
+
+import           Cardano                      (ConfigurationYaml, applicationVersion, update)
+import           Github                       (Rev)
+import           Nix                          (nixEvalExpr, nixBuildExpr)
+import           Types
+import           Utils                        (tt)
+
+data GlobalResults = GlobalResults {
+      grCardanoCommit      :: Text
+    , grDaedalusCommit     :: Text
+    , grApplicationVersion :: Int
+    , grCardanoVersion     :: Text
+    , grDaedalusVersion    :: Text
+  } deriving (Show, Generic)
+
+instance FromJSON GlobalResults
+instance ToJSON GlobalResults
+
+findVersionInfo :: ApplicationVersionKey -> Rev -> IO GlobalResults
+findVersionInfo keys grDaedalusCommit = do
+  grApplicationVersion <- grabAppVersion grDaedalusCommit keys
+  printf ("applicationVersion: "%d%"\n") grApplicationVersion
+  grCardanoVersion <- fetchCardanoVersionFromDaedalus grDaedalusCommit
+  printf ("Cardano version: "%s%"\n") grCardanoVersion
+  grDaedalusVersion <- fetchDaedalusVersion grDaedalusCommit
+  printf ("Daedalus version: "%s%"\n") grDaedalusVersion
+  grCardanoCommit <- fetchCardanoCommitFromDaedalus grDaedalusCommit
+  printf ("Cardano commit: "%s%"\n") grCardanoCommit
+  pure GlobalResults{..}
+
+-- | Gets package.json version from Daedalus sources.
+fetchDaedalusVersion :: Text -> IO Text
+fetchDaedalusVersion rev = getVersion <$> fetchDaedalusJSON "package.json" rev
+  where
+    getVersion v = v ^?! key "version" . _String
+
+-- | Gets the git rev from cardano-sl-src.json in Daedalus
+fetchCardanoCommitFromDaedalus :: Rev -> IO Rev
+fetchCardanoCommitFromDaedalus rev = getRev <$> fetchDaedalusJSON "cardano-sl-src.json" rev
+  where
+    getRev v = v ^?! key "rev" . _String
+
+fetchDaedalusJSON :: FilePath -> Text -> IO S8.ByteString
+fetchDaedalusJSON json rev = do
+  res <- nixEvalExpr (fetchDaedalusNixExpr rev)
+  loadFile json (FP.fromText $ (res ^?! _String))
+  where
+    loadFile fpath storePath = S8.readFile (FP.encodeString $ storePath </> fpath)
+
+-- | Gets version string from daedalus-bridge attribute of Daedalus default.nix
+fetchCardanoVersionFromDaedalus :: Text -> IO Text
+fetchCardanoVersionFromDaedalus rev = getString <$> nixEvalExpr expr
+  where
+    getString val = val ^?! _String
+    expr = format ("(import "%s%" {}).daedalus-bridge.version") (fetchDaedalusNixExpr rev)
+
+-- | Returns the store path of daedalus-bridge.
+fetchDaedalusBridge :: Rev -> IO FilePath
+fetchDaedalusBridge rev = nixBuildExpr expr
+  where expr = format ("(import "%s%" {}).daedalus-bridge") (fetchDaedalusNixExpr rev)
+
+-- | A nix expression to import a specific revision of Deadalus from git.
+fetchDaedalusNixExpr :: Rev -> Text
+fetchDaedalusNixExpr = format ("(builtins.fetchTarball "%s%s%".tar.gz)") url
+  where url = "https://github.com/input-output-hk/daedalus/archive/" :: Text
+
+-- | Gets version information from the config files in the
+-- daedalus-bridge derivation.
+grabAppVersion :: Rev     -- ^ git commit id to check out
+               -> ApplicationVersionKey -- ^ yaml keys to find
+               -> IO Int     -- ^ an integer version
+grabAppVersion rev key = do
+  bridge <- fetchDaedalusBridge rev
+  Just fullConfiguration <- Y.decodeFile (FP.encodeString $ bridge </> "config/configuration.yaml")
+  appVersionFromConfig key fullConfiguration
+
+appVersionFromConfig :: ApplicationVersionKey -> ConfigurationYaml -> IO Int
+appVersionFromConfig key cfg = case (ver Win64, ver Mac64) of
+  (Nothing, _)            -> fail "configuration-key missing"
+  (_, Nothing)            -> fail "configuration-key missing"
+  (win, mac) | win /= mac -> fail "applicationVersions dont match"
+  (Just val, Just _)      -> pure (applicationVersion $ update val)
+  where
+    ver a = HM.lookup (key a) cfg
+
+----------------------------------------------------------------------------
+
+-- | Cardano cluster which the installer will connect to.
+data InstallerNetwork = InstallerMainnet | InstallerStaging deriving (Eq)
+
+instance Show InstallerNetwork where
+  show InstallerMainnet = "Mainnet"
+  show InstallerStaging = "Staging"
+
+-- | Determine which cardano network an installer is for based on its
+-- filename. The inverse of this function is in
+-- daedalus/installers/Types.hs.
+installerNetwork :: FilePath -> Maybe InstallerNetwork
+installerNetwork fpath | "mainnet" `T.isInfixOf` name = Just InstallerMainnet
+                       | "staging" `T.isInfixOf` name = Just InstallerStaging
+                       | otherwise = Nothing
+  where name = tt (filename fpath)

--- a/iohk/Nix.hs
+++ b/iohk/Nix.hs
@@ -1,23 +1,30 @@
-{-# LANGUAGE DataKinds, DeriveGeneric, FlexibleInstances, GADTs, KindSignatures, OverloadedStrings, RecordWildCards, StandaloneDeriving, ViewPatterns #-}
+{-# LANGUAGE DataKinds, DeriveGeneric, DeriveDataTypeable, FlexibleInstances, GADTs, KindSignatures, OverloadedStrings, RecordWildCards, StandaloneDeriving, ViewPatterns #-}
 {-# OPTIONS_GHC -Wall -Wno-name-shadowing -Wno-orphans -Wno-missing-signatures #-}
 
 module Nix where
 
+import           Prelude                   hiding (FilePath)
+
+import           Control.Monad.Catch              (Exception, throwM, MonadThrow)
 import qualified Data.Aeson                    as AE
-import           Data.Aeson                       ((.:), (.=))
-import qualified Data.ByteString.Lazy          as BL
-import           Data.ByteString.Lazy.Char8       (ByteString)
+import           Data.Aeson                       ((.:), (.=), eitherDecodeStrict, Value)
+import qualified Data.ByteString.Lazy.Char8    as L8
+import qualified Data.ByteString.Char8         as S8
 import           Data.Foldable                    (asum)
 import qualified Data.Map.Strict               as Map
 import           Data.Maybe
 import           Data.Text                        (Text, toTitle)
 import qualified Data.Text                     as T
+import qualified Data.Text.IO                  as T
+import qualified Data.Text.Encoding            as T
+import           Data.Text.Encoding.Error         (lenientDecode)
+import           Data.Typeable                    (Typeable)
 import           Data.Yaml                        (FromJSON(..), ToJSON(..))
-import           GHC.Generics              hiding (from, to)
-import           Prelude                   hiding (FilePath)
-import           Turtle                    hiding (env, err, fold, prefix, procs, e, f, o, x)
 import           Filesystem.Path                  (FilePath)
 import qualified Filesystem.Path.CurrentOS     as FP
+import           GHC.Generics              hiding (from, to)
+import           Turtle                    hiding (env, err, fold, prefix, procs, e, f, o, x)
+import qualified Turtle.Bytes                  as B
 
 import Constants
 import Types
@@ -63,16 +70,16 @@ instance FromJSON (NixSource 'Github) where
       <*> v .: "rev"
       <*> v .: "sha256"
 
-githubSource :: ByteString -> Maybe (NixSource 'Github)
+githubSource :: L8.ByteString -> Maybe (NixSource 'Github)
 githubSource = AE.decode
-gitSource    :: ByteString -> Maybe (NixSource 'Git)
+gitSource    :: L8.ByteString -> Maybe (NixSource 'Git)
 gitSource    = AE.decode
 
 -- XXX: make independent of Constants
-readSource :: (ByteString -> Maybe (NixSource a)) -> Project -> IO (NixSource a)
+readSource :: (L8.ByteString -> Maybe (NixSource a)) -> Project -> IO (NixSource a)
 readSource parser (projectSrcFile -> path) =
   (fromMaybe (errorT $ format ("File doesn't parse as NixSource: "%fp) path) . parser)
-  <$> BL.readFile (T.unpack $ format fp path)
+  <$> L8.readFile (T.unpack $ format fp path)
 
 instance FromJSON FilePath where parseJSON = AE.withText "filepath" $ \v -> pure $ fromText v
 instance ToJSON   FilePath where toJSON    = AE.String . format fp
@@ -112,15 +119,26 @@ fromNixStr (NixStr s) = s
 fromNixStr x = error $ "fromNixStr, got a non-NixStr: " <> show x
 
 -- | Evaluate a nix expression, returning its value in nix syntax.
-nixEvalExpr :: T.Text -> Shell Line
-nixEvalExpr expr = inproc "nix-instantiate" [ "--read-write-mode" , "--eval" , "--expr", expr ] empty
+nixEvalExpr :: Text -> IO Value
+nixEvalExpr expr = eval >>= parseNixOutput
+  where eval = procNix "nix-instantiate" [ "--json", "--read-write-mode" , "--eval" , "--expr", expr ]
 
 -- | Build a nix expression, returning the store path.
-nixBuildExpr :: T.Text -> IO FilePath
-nixBuildExpr expr = nixBuild & strict & fmap (FP.fromText . T.stripEnd)
-  where nixBuild = inproc "nix-build" ["--no-out-link", "--expr", expr] empty
+nixBuildExpr :: Text -> IO FilePath
+nixBuildExpr expr = fp <$> procNix "nix-build" ["--no-out-link", "--expr", expr]
+  where fp = FP.decode . S8.takeWhile (/= '\n')
 
--- | Cheap and nasty conversion of a quoted string to an unquoted
--- string.
-unquoteNixString :: T.Text -> T.Text
-unquoteNixString = T.drop 1 . T.dropEnd 1 . T.strip
+data NixError = NixError { nixErrorStatus :: Int, nixErrorMessage :: Text } deriving (Show, Typeable)
+instance Exception NixError
+
+parseNixOutput :: (MonadThrow m, FromJSON a) => S8.ByteString -> m a
+parseNixOutput json = case eitherDecodeStrict json of
+  Right val -> pure val
+  Left e -> throwM $ NixError 0 ("Could not parse nix output: " <> T.pack e)
+
+procNix :: Text -> [Text] -> IO S8.ByteString
+procNix cmd args = log >> B.procStrictWithErr cmd args empty >>= handle
+  where
+    log = T.putStrLn $ T.intercalate " " (cmd:args)
+    handle (ExitSuccess, out, _) = pure out
+    handle (ExitFailure status, _, err) = throwM $ NixError status (T.decodeUtf8With lenientDecode err)

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -806,7 +806,7 @@ build o _c depl = do
 -- | Use nix to grab the sources of cardano-sl.
 getCardanoSLSource :: Options -> IO Path.FilePath
 getCardanoSLSource o = parent . fromText <$> incmdStrip o "nix-instantiate" args
-  where args = [ "--eval", "-A", "cardano-sl.src", "default.nix" ]
+  where args = [ "--read-write-mode", "--eval", "-A", "cardano-sl.src", "default.nix" ]
 
 
 -- * State management

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -911,9 +911,13 @@ configurationKeys Staging    Win64 = "mainnet_dryrun_wallet_win64"
 configurationKeys Staging    Mac64 = "mainnet_dryrun_wallet_macos64"
 configurationKeys env _ = error $ "Application versions not used in '" <> show env <> "' environment"
 
-findInstallers :: T.Text -> NixopsConfig -> IO ()
-findInstallers daedalusRev c = with installers printInstallersResults
-  where installers = realFindInstallers (configurationKeys $ cEnvironment c) (const True) daedalusRev
+findInstallers :: NixopsConfig -> T.Text -> Maybe FilePath -> IO ()
+findInstallers c daedalusRev destDir = do
+  installers <- realFindInstallers (configurationKeys $ cEnvironment c) (const True) daedalusRev destDir
+  printInstallersResults installers
+  case destDir of
+    Just dir -> void $ proc "ls" [ "-ltrha", tt dir ] mempty
+    Nothing -> pure ()
 
 wipeJournals :: Options -> NixopsConfig -> IO ()
 wipeJournals o c@NixopsConfig{..} = do

--- a/iohk/Types.hs
+++ b/iohk/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# OPTIONS_GHC -Wall -Wno-name-shadowing -Wno-missing-signatures -Wno-type-defaults #-}
 
 module Types where

--- a/iohk/Types.hs
+++ b/iohk/Types.hs
@@ -41,12 +41,17 @@ newtype FQDN         = FQDN         { fromFQDN         :: Text   } deriving (Fro
 newtype IP           = IP           { getIP            :: Text   } deriving (Show, Generic, FromField)
 newtype PortNo       = PortNo       { fromPortNo       :: Int    } deriving (FromJSON, Generic, Show, ToJSON)
 newtype Username     = Username     { fromUsername     :: Text   } deriving (FromJSON, Generic, Show, IsString, ToJSON)
-data Arch = Linux64 | Mac64 | Win64 deriving Show
-newtype ApplicationVersionKey (a :: Arch) = ApplicationVersionKey Text deriving IsString
-newtype ApplicationVersion (a :: Arch) = ApplicationVersion Text deriving (IsString, Show, Eq, Generic, ToJSON)
+data Arch = Linux64 | Mac64 | Win64 deriving (Show, Read, Eq, Generic)
+newtype ApplicationVersion = ApplicationVersion { getApplicationVersion :: Text } deriving (FromJSON, IsString, Show, Eq, Generic, ToJSON)
+type ApplicationVersionKey = Arch -> Text
 
-getApplicationVersion :: ApplicationVersion a -> Text
-getApplicationVersion (ApplicationVersion v) = v
+instance FromJSON Arch
+instance ToJSON Arch
+
+formatArch :: Arch -> Text
+formatArch Linux64 = "Linux"
+formatArch Mac64 = "macOS"
+formatArch Win64 = "Windows"
 
 -- * Flags
 --

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -13,7 +13,6 @@ module UpdateLogic
   , ciResultLocalPath
   , ciResultVersion
   , ciResultUrl
-  , hashInstaller
   , uploadHashedInstaller
   , uploadSignature
   , updateVersionJson
@@ -426,21 +425,6 @@ findInstaller buildkiteToken daedalus_rev daedalus_version tempdir keys status =
     Nothing -> do
       putStrLn $ "unrecognized CI status: " <> T.unpack (context status)
       pure (Nothing, Nothing)
-
-hashInstaller :: T.Text -> IO T.Text
-hashInstaller path = do
-  let
-    -- TODO DEVOPS-502
-    -- once cardano in `cardano-sl-src.json` has been bumped enough, switch this to building on the fly
-    -- with `nix-build -A cardano-sl-auxx`
-    exepath :: T.Text
-    exepath = "/nix/store/hjvv6dxy197c9mjc2gh635am0c0shx5l-cardano-sl-auxx-1.0.3/bin/cardano-hash-installer"
-  (exitStatus, res) <- procStrict exepath [ path ] empty
-  case exitStatus of
-    ExitSuccess -> do
-      let cleanHash = fromMaybe res (T.stripSuffix "\n" res)
-      return cleanHash
-    ExitFailure _ -> error "error running cardano-hash-installer"
 
 githubWikiRecord :: InstallersResults -> T.Text
 githubWikiRecord results = join [ T.pack $ show appVersion

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -1,28 +1,25 @@
 {-# OPTIONS_GHC -Weverything -Wno-unsafe -Wno-implicit-prelude -Wno-missing-local-signatures #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module UpdateLogic
   ( realFindInstallers
-  , CiResult(..)
-  , ciResultLocalPath
-  , ciResultVersion
-  , ciResultUrl
+  , CIResult(..)
   , uploadHashedInstaller
   , uploadSignature
   , updateVersionJson
   , githubWikiRecord
+  , printInstallersResults
   , InstallersResults(..)
   , GlobalResults(..)
   , parseStatusContext
   , StatusContext(..)
-  , resultLocalPath
-  , resultDesc
   , bucketRegion
   , runAWS'
   ) where
@@ -31,6 +28,7 @@ import           Prelude                      hiding (FilePath)
 import           Appveyor                     (AppveyorArtifact (AppveyorArtifact),
                                                build, fetchAppveyorArtifacts,
                                                fetchAppveyorBuild,
+                                               buildNumber, unBuildNumber,
                                                getArtifactUrl, jobId,
                                                parseCiUrl)
 import qualified Appveyor
@@ -39,44 +37,25 @@ import           Buildkite.API                (APIToken(APIToken)
                                               , artifactFilename, artifactSha1sum
                                               , listArtifactsForBuild)
 import qualified Buildkite.API                as BK
-import qualified Buildkite.Pipeline           as BK
-import           Cardano                      (ConfigurationYaml,
-                                               applicationVersion, update)
-import           Control.Applicative          ((<|>), liftA2)
-import           Control.Exception            (Exception, catch, throwIO, try)
+import           Control.Applicative          ((<|>))
+import           Control.Exception            (try)
 import           Control.Lens                 (to, (^.))
 import qualified Control.Lens                 as Lens
-import           Control.Monad                (guard)
-import           Control.Monad.Managed        (Managed, liftIO, with)
+import           Control.Monad                (guard, forM)
+import           Control.Monad.Managed        (Managed, liftIO)
 import           Control.Monad.Trans.Resource (runResourceT)
-import           Data.Aeson                   (ToJSON, encode, decode)
-import qualified Data.ByteString              as BS
-import qualified Data.ByteString.Char8        as BSC
+import           Data.Aeson                   (ToJSON, FromJSON)
 import qualified Data.ByteString.Lazy         as LBS
-import           Data.Coerce                  (coerce)
-import           Data.Git                     (Blob (Blob),
-                                               Commit (commitTreeish), EntName,
-                                               ModePerm, Ref,
-                                               Tree (treeGetEnts),
-                                               blobGetContent, entName,
-                                               getCommit, getTree)
-import           Data.Git.Ref                 (SHA1, fromHexString)
-import           Data.Git.Repository          ()
-import           Data.Git.Storage             (Git, getObject, isRepo, openRepo)
-import           Data.Git.Storage.Object      (Object (ObjBlob))
 import qualified Data.HashMap.Strict          as HashMap
-import           Data.List                    (find)
-import           Data.Maybe                   (fromJust, fromMaybe, listToMaybe, catMaybes)
+import           Data.List                    (nub)
 import           Data.Monoid                  ((<>))
 import qualified Data.Text                    as T
 import qualified Data.Text.IO                 as T
-import qualified Data.Yaml                    as Y
 import qualified Filesystem.Path.CurrentOS    as FP
 import           GHC.Generics                 (Generic)
-import           GHC.Stack                    (HasCallStack)
 import           Github                       (Status, context,
                                                fetchGithubStatus, statuses,
-                                               targetUrl, GitHubSource(srcRev), Rev)
+                                               targetUrl, Rev)
 import           Network.AWS                  (Credentials (Discover), newEnv,
                                                send, toBody, within, Region,
                                                AWS, runAWS,
@@ -89,136 +68,42 @@ import           Network.AWS.S3.Types         (BucketName (BucketName), constrai
                                                ObjectKey (ObjectKey))
 import           Network.AWS.S3.PutObject
 import           Network.AWS.S3.CopyObject
-import qualified Network.AWS.Data             as AWS
 import           Network.URI                  (uriPath, parseURI)
 import           Safe                         (headMay, lastMay, readMay)
-import           System.Console.ANSI          (Color (Green, Red),
+import           System.Console.ANSI          (Color (Green),
                                                ColorIntensity (Dull),
-                                               ConsoleLayer (Background, Foreground),
+                                               ConsoleLayer (Foreground),
                                                SGR (Reset, SetColor), setSGR)
 import           System.IO.Error              (ioeGetErrorString)
-import           System.Exit                  (ExitCode (ExitFailure, ExitSuccess), die)
-import           Text.Regex.PCRE              ((=~))
-import           Turtle                       (FilePath, empty, void, MonadIO, format, fp)
-import           Turtle.Prelude               (mktempdir, proc, procStrict,
-                                               pushd)
-import           Types                        (ApplicationVersion (ApplicationVersion),
-                                               ApplicationVersionKey (ApplicationVersionKey),
-                                               Arch (Linux64, Mac64, Win64),
-                                               getApplicationVersion)
+import           System.Exit                  (die)
+import           Turtle                       (void, MonadIO, printf, format, fp, d, s, w, (%))
+import           Turtle.Prelude               (mktempdir, proc)
+import           Filesystem.Path              (FilePath, (</>), filename)
+
+import           InstallerVersions
+import           Types                        (ApplicationVersion, ApplicationVersionKey,
+                                               Arch (Mac64, Win64), formatArch)
 import           Utils                        (fetchCachedUrl, fetchCachedUrlWithSHA1, s3Link)
 
-data CiResult = AppveyorResult
-                { avLocalPath :: T.Text
-                , avVersion   :: ApplicationVersion 'Win64
-                , avUrl       :: T.Text
-                }
-              | BuildkiteResult
-                { bkLocalPath     :: T.Text
-                , bkVersion       :: ApplicationVersion 'Mac64
-                , bkCardanoCommit :: T.Text
-                , bkBuildNumber   :: Int
-                , bkUrl           :: T.Text
-                }
-              deriving (Show, Generic)
-
-ciResultLocalPath :: CiResult -> T.Text
-ciResultLocalPath (AppveyorResult p _ _) = p
-ciResultLocalPath (BuildkiteResult p _ _ _ _) = p
-
-ciResultVersion :: CiResult -> T.Text
-ciResultVersion (AppveyorResult _ v _) = getApplicationVersion v
-ciResultVersion (BuildkiteResult _ v _ _ _) = getApplicationVersion v
-
-ciResultUrl :: CiResult -> T.Text
-ciResultUrl (AppveyorResult _ _ u) = u
-ciResultUrl (BuildkiteResult _ _ _ _ u) = u
-
-data GlobalResults = GlobalResults {
-      grCardanoCommit      :: T.Text
-    , grDaedalusCommit     :: T.Text
-    , grApplicationVersion :: Int
+data CIResult = CIResult
+  { ciResultLocalPath   :: FilePath
+  , ciResultUrl         :: T.Text
+  , ciResultDownloadUrl :: T.Text
+  , ciResultBuildNumber :: Int
   } deriving (Show, Generic)
+
 data InstallersResults = InstallersResults
-  { appveyorResult  :: Maybe CiResult
-  , buildkiteResult :: Maybe CiResult
-  , globalResult    :: GlobalResults
+  { ciResults    :: [(Arch, CIResult)]
+  , globalResult :: GlobalResults
   } deriving (Show, Generic)
-type TextPath = T.Text
-type RepoUrl = T.Text
 
--- | Get VERSION environment variable from pipeline definition.
--- First looks in global env, otherwise finds first build step with a version.
-extractVersionFromBuildkite :: BK.PipelineDefinition -> Maybe T.Text
-extractVersionFromBuildkite BK.PipelineDefinition{..} = getVer plEnv <|> headMay stepVers
-  where
-    stepVers = catMaybes [getVer (BK.stepEnv step) | step <- plSteps]
-    getVer = HashMap.lookup "VERSION" :: HashMap.HashMap T.Text T.Text -> Maybe T.Text
+instance FromJSON InstallersResults
+instance FromJSON CIResult
+instance ToJSON InstallersResults
+instance ToJSON CIResult
 
-data GitNotFound = GitFileNotFound T.Text | GitDirNotFound deriving Show
-
-instance Exception GitNotFound
-
-readFileFromGit :: HasCallStack => T.Text -> T.Text -> T.Text -> RepoUrl -> IO (Maybe LBS.ByteString)
-readFileFromGit rev path name url = do
-  let clonePath = "/tmp/gitcache-" <> name
-  putStrLn $ "Cloning or fetching to " <> T.unpack clonePath
-  repo <- fetchOrClone clonePath url
-  putStrLn $ "Getting " <> T.unpack rev <> ":" <> T.unpack path
-  let
-    pathParts = T.splitOn "/" path
-    lookupTree :: T.Text -> Ref SHA1 -> IO (Maybe (Ref SHA1))
-    lookupTree name' dirRef = do
-      dir <- getTree repo dirRef
-      let
-        resultList = filter (travisFiler $ BSC.pack $ T.unpack name') (treeGetEnts dir)
-      return $ fmap (\(_, _, x) -> x) $ listToMaybe resultList
-    go :: HasCallStack => [T.Text] -> Ref SHA1 -> IO (Ref SHA1)
-    go [] _ = error "empty path??"
-    go [ file ] ref = lookupTree file ref >>= \refOut -> maybe (throwIO (GitFileNotFound path)) pure refOut
-    go ( dir : rest ) ref = lookupTree dir ref >>= maybe (throwIO GitDirNotFound) (go rest)
-    travisFiler :: BS.ByteString -> (ModePerm, EntName, Ref SHA1) -> Bool
-    travisFiler needle (_, currentFile, _) = currentFile == entName needle
-  commit <- getCommit repo (fromHexString $ T.unpack rev)
-  travisRef <- go pathParts (commitTreeish commit)
-  obj <- getObject repo travisRef True
-  case obj of
-    Just (ObjBlob (Blob { blobGetContent = content })) -> do
-      return $ Just content
-    _ -> return Nothing
-
-readDaedalusFile :: HasCallStack => T.Text -> T.Text -> IO (Maybe LBS.ByteString)
-readDaedalusFile rev path = catch (readFileFromGit rev path "daedalus" repo) notFound
-  where
-    repo = "https://github.com/input-output-hk/daedalus" :: T.Text
-    notFound :: GitNotFound -> IO (Maybe LBS.ByteString)
-    notFound _ = pure Nothing
-
-fetchDaedalusRepoYAML :: Y.FromJSON a => T.Text -> T.Text -> IO (Maybe a)
-fetchDaedalusRepoYAML rev path = do
-  res <- readDaedalusFile rev path
-  case res of
-    Just yaml -> case Y.decodeEither (LBS.toStrict yaml) of
-      Right a -> return (Just a)
-      Left err -> fail $ "unable to parse " <> T.unpack path <> ": " <> err
-    Nothing -> return Nothing
-
-fetchDaedalusVersion :: T.Text -> IO T.Text
-fetchDaedalusVersion rev = do
-  pipeline <- fetchDaedalusRepoYAML rev ".buildkite/pipeline.yml"
-  case extractVersionFromBuildkite =<< pipeline of
-    Just ver -> pure ver
-    Nothing -> fail "unable to find daedalus version in .buildkite/pipeline.yml"
-
-fetchDaedalusCardanoSource :: T.Text -> IO GitHubSource
-fetchDaedalusCardanoSource daedalusRev = do
-  js <- readDaedalusFile daedalusRev "cardano-sl-src.json"
-  case decode =<< js of
-    Just ver -> return ver
-    Nothing -> fail "unable to parse version info in cardano-sl-src.json"
-
-findCardanoRevisionFromDaedalus :: T.Text -> IO Rev
-findCardanoRevisionFromDaedalus = fmap srcRev . fetchDaedalusCardanoSource
+-- | Allow selection of which CI artifacts to download.
+type InstallerPredicate = CIResult -> Bool
 
 -- | Read the Buildkite token from a config file. This file is not
 -- checked into git, so the user needs to create it themself.
@@ -237,148 +122,110 @@ loadBuildkiteToken = try (T.readFile buildkiteTokenFile) >>= \case
 
 buildkiteTokenFile = "static/buildkite_token" :: String
 
-realFindInstallers :: HasCallStack => T.Text -> (ApplicationVersionKey 'Win64, ApplicationVersionKey 'Mac64) -> Managed InstallersResults
-realFindInstallers daedalus_rev keys = do
-  buildkiteToken <- liftIO loadBuildkiteToken
-  obj <- liftIO $ fetchGithubStatus "input-output-hk" "daedalus" daedalus_rev
-  daedalusVersion <- liftIO $ fetchDaedalusVersion daedalus_rev
+realFindInstallers :: ApplicationVersionKey -> InstallerPredicate -> Rev -> Managed InstallersResults
+realFindInstallers keys instP daedalusRev = do
+  buildkiteToken <- liftIO $loadBuildkiteToken
+  globalResult <- liftIO $findVersionInfo keys daedalusRev
+  st <- liftIO $ statuses <$> fetchGithubStatus "input-output-hk" "daedalus" daedalusRev
   tempdir <- mktempdir "/tmp" "iohk-ops"
-  results <- liftIO $ mapM (findInstaller buildkiteToken daedalus_rev daedalusVersion (T.pack $ FP.encodeString tempdir) keys) (statuses obj)
-  let
-    findResult :: (CiResult -> Bool) -> [(Maybe GlobalResults, Maybe CiResult)] -> Maybe CiResult
-    findResult p = headMay . filter p . catMaybes . map snd
-    findGlobal :: [ (Maybe GlobalResults, Maybe CiResult) ] -> GlobalResults
-    findGlobal = head . catMaybes . map fst
-  _ <- proc "ls" [ "-ltrha", T.pack $ FP.encodeString tempdir ] mempty
-  return $ InstallersResults
-    (findResult isAppveyorResult results)
-    (findResult isBuildkiteResult results)
-    (findGlobal results)
-
-isAppveyorResult, isBuildkiteResult :: CiResult -> Bool
-isAppveyorResult  (AppveyorResult _ _ _)      = True
-isAppveyorResult  _                           = False
-isBuildkiteResult (BuildkiteResult _ _ _ _ _) = True
-isBuildkiteResult _                           = False
-
--- | Path to where build result is downloaded.
-resultLocalPath :: CiResult -> T.Text
-resultLocalPath (AppveyorResult p _ _) = p
-resultLocalPath (BuildkiteResult p _ _ _ _) = p
-
--- | Text describing what the build result is
-resultDesc :: CiResult -> T.Text
-resultDesc (AppveyorResult _ _ _) = "windows installer"
-resultDesc (BuildkiteResult _ _ _ _ _) = "darwin installer (from Buildkite)"
-
-fetchOrClone :: TextPath -> RepoUrl -> IO (Git SHA1)
-fetchOrClone localpath url = do
-  res <- isRepo (FP.decodeString $ T.unpack localpath)
-  case res of
-    True -> do
-      fetchRepo localpath url
-    False -> do
-      exitCode <- proc "git" [ "clone", "--mirror", url, localpath ] mempty
-      case exitCode of
-        ExitSuccess   -> fetchRepo localpath url
-        ExitFailure _ -> error "cant clone repo"
-
-fetchRepo :: T.Text -> T.Text -> IO (Git SHA1)
-fetchRepo localpath url = do
-  let
-    fetcher :: Managed (Git SHA1)
-    fetcher = do
-      pushd  $ FP.decodeString $ T.unpack localpath
-      exitCode <- proc "git" [ "fetch", url ] mempty
-      case exitCode of
-        ExitSuccess -> liftIO $ openRepo $ FP.decodeString $ T.unpack localpath
-        ExitFailure _ -> error "cant fetch repo"
-  with fetcher $ \res -> pure res
+  results <- liftIO $ concat <$> mapM (findInstallersFromStatus buildkiteToken tempdir instP) st
+  void $ proc "ls" [ "-ltrha", format fp tempdir ] mempty
+  pure $ InstallersResults results globalResult
 
 buildkiteOrg     = "input-output-hk" :: T.Text
 pipelineDaedalus = "daedalus"        :: T.Text
 
-artifactIsInstaller :: Artifact -> Bool
-artifactIsInstaller = T.isSuffixOf ".pkg" . artifactFilename
+bkArtifactIsInstaller :: Artifact -> Bool
+bkArtifactIsInstaller = T.isSuffixOf ".pkg" . artifactFilename
 
-processDarwinBuildKite :: APIToken -> T.Text -> T.Text -> T.Text -> Int -> (ApplicationVersionKey 'Win64, ApplicationVersionKey 'Mac64) -> T.Text -> IO (GlobalResults, CiResult)
-processDarwinBuildKite apiToken daedalus_rev daedalus_version tempdir buildNum versionKey ciUrl = do
-  cardanoRev <- findCardanoRevisionFromDaedalus daedalus_rev
+findInstallersBuildKite :: APIToken -> FilePath -> InstallerPredicate -> Int -> T.Text -> IO [(Arch, CIResult)]
+findInstallersBuildKite apiToken tempdir instP buildNum buildUrl = do
   arts <- listArtifactsForBuild apiToken buildkiteOrg pipelineDaedalus buildNum
 
-  case find artifactIsInstaller arts of
-    Just art -> do
-      let outFile = tempdir <> "/" <> artifactFilename art
+  rs <- forInstallers bkArtifactIsInstaller arts $ \art -> do
+    -- ask Buildkite what the download URL is
+    url <- BK.getArtifactURL apiToken buildkiteOrg pipelineDaedalus buildNum art
 
-      -- ask Buildkite what the download URL is
-      url <- BK.getArtifactURL apiToken buildkiteOrg pipelineDaedalus buildNum art
+    let out = tempdir </> FP.fromText (artifactFilename art)
+        res = CIResult out buildUrl url buildNum
+    printCIResult "Buildkite" Mac64 res
+    pure (res, artifactSha1sum art)
 
-      printDarwinBuildInfo "buildkite" cardanoRev url
+  forM (filter (instP . fst) rs) $ \(res, sha1) -> do
+    -- download artifact into nix store
+    let out = ciResultLocalPath res
+    fetchCachedUrlWithSHA1 (ciResultDownloadUrl res) (filename out) out sha1
+    pure (Mac64, res)
 
-      -- download artifact into nix store
-      fetchCachedUrlWithSHA1 url (artifactFilename art) outFile (artifactSha1sum art)
+avArtifactIsInstaller :: AppveyorArtifact -> Bool
+avArtifactIsInstaller (AppveyorArtifact _ name) = name == "Daedalus Win64 Installer"
 
-      appVersion <- liftIO $ grabAppVersion cardanoRev versionKey
+findInstallersAppVeyor :: FilePath -> InstallerPredicate -> T.Text
+                       -> Appveyor.Username -> Appveyor.Project -> ApplicationVersion
+                       -> IO [(Arch, CIResult)]
+findInstallersAppVeyor tempdir instP url user project version = do
+  appveyorBuild <- fetchAppveyorBuild user project version
+  let jobid = appveyorBuild ^. build . Appveyor.jobs . to head . jobId
+  artifacts <- fetchAppveyorArtifacts jobid
+  rs <- forInstallers avArtifactIsInstaller artifacts $ \(AppveyorArtifact art _) ->
+    pure CIResult
+      { ciResultLocalPath = tempdir </> filename (FP.fromText art)
+      , ciResultUrl = url
+      , ciResultDownloadUrl = getArtifactUrl jobid art
+      , ciResultBuildNumber = appveyorBuild ^. build . buildNumber . to unBuildNumber
+      }
 
-      let res = BuildkiteResult
-            { bkLocalPath = outFile
-            , bkVersion = makeDaedalusVersion daedalus_version buildNum
-            , bkCardanoCommit = cardanoRev
-            , bkBuildNumber = buildNum
-            , bkUrl = ciUrl
-            }
-      pure (GlobalResults cardanoRev daedalus_rev appVersion, res)
+  forM (filter instP rs) $ \res -> do
+    printCIResult "AppVeyor" Win64 res
+    let out = ciResultLocalPath res
+    fetchCachedUrl (ciResultDownloadUrl res) (filename out) out
+    pure (Win64, res)
 
-    Nothing -> die $ if null arts
-      then "No artifacts for job"
-      else "Installer package file not found in artifacts"
+forInstallers :: (a -> Bool) -> [a] -> (a -> IO b) -> IO [b]
+forInstallers p arts action = case filter p arts of
+  [] -> die $ if null arts
+    then "No artifacts for job"
+    else "Installer package file not found in artifacts"
+  files -> mapM action files
 
-makeDaedalusVersion :: T.Text -> Int -> ApplicationVersion a
-makeDaedalusVersion ver = makeDaedalusVersion' ver . T.pack . show
-
-makeDaedalusVersion' :: T.Text -> T.Text -> ApplicationVersion a
-makeDaedalusVersion' ver num = ApplicationVersion $ ver <> "." <> num
-
-printDarwinBuildInfo :: String -> T.Text -> T.Text -> IO ()
-printDarwinBuildInfo ci cardanoRev url = do
-  putStr "cardano commit: "
-  putStr (T.unpack $ cardanoRev)
-  setSGR [ Reset ]
-  putStr "\n"
-
-  putStr $ ci <> " URL: "
+printCIResult :: T.Text -> Arch -> CIResult -> IO ()
+printCIResult ci arch CIResult{..} = do
+  printf (s%" "%w%" URL: ") ci arch
   setSGR [ SetColor Foreground Dull Green ]
-  putStrLn $ T.unpack url
+  T.putStrLn ciResultUrl
   setSGR [ Reset ]
 
--- | Gets version information from the config files in the cardano-sl git repo.
-grabAppVersion :: T.Text     -- ^ git commit id to check out
-               -> (ApplicationVersionKey 'Win64, ApplicationVersionKey 'Mac64) -- ^ yaml keys to find
-               -> IO Int     -- ^ an integer version, not sure really
-grabAppVersion rev (winKey, macosKey) = do
-    let
-      readPath name = readFileFromGit rev name "cardano" "https://github.com/input-output-hk/cardano-sl"
-      readPath1 = readPath "lib/configuration.yaml"
-      readPath2 = readPath "node/configuration.yaml"
-      fallback :: GitNotFound -> IO (Maybe LBS.ByteString)
-      fallback _ = readPath2
-    Just content <- catch readPath1 fallback
-    let
-      fullConfiguration :: ConfigurationYaml
-      fullConfiguration = fromJust . Y.decode . LBS.toStrict $ content
-      winVersion = HashMap.lookup (coerce winKey) fullConfiguration
-      macosVersion = HashMap.lookup (coerce macosKey) fullConfiguration
-    -- relies on only parsing out the subset that should match
-    if winVersion == macosVersion then
-      case winVersion of
-        Just val -> do
-          T.putStrLn ("applicationVersion is " <> (T.pack $ show $ applicationVersion $ update val))
-          return $ applicationVersion $ update val
-        Nothing -> error $ "configuration-key missing"
-    else
-      error $ "applicationVersions dont match"
+  printf (s%" "%w%" Installer: ") ci arch
+  setSGR [ SetColor Foreground Dull Green ]
+  T.putStrLn ciResultDownloadUrl
+  setSGR [ Reset ]
 
-data StatusContext = StatusContextAppveyor Appveyor.Username Appveyor.Project (ApplicationVersion 'Win64)
+formatCIResults :: [(Arch, CIResult)] -> T.Text
+formatCIResults rs = T.unlines $ ["CI links:"] ++ ciLinks ++ [""] ++ instLinks InstallerMainnet ++ [""] ++ instLinks InstallerStaging
+  where
+    ciLinks = nub $ map (("* " <>) . ciResultUrl . snd) rs
+    instLinks net = (format (w%" installers:") net:[ fmt arch (ciResultDownloadUrl res)
+                                                   | (arch, res) <- rs, isNet net res ])
+    isNet net = (== Just net) . installerNetwork . ciResultLocalPath
+    fmt arch = format (s%" - "%s) (formatArch arch)
+
+formatVersionInfo :: GlobalResults -> T.Text
+formatVersionInfo GlobalResults{..} = T.unlines
+  [ format ("Daedalus version:   "%s) grDaedalusVersion
+  , format ("Daedalus rev:       "%s) grDaedalusCommit
+  , ""
+  , format ("Cardano SL version: "%s) grCardanoVersion
+  , format ("Cardano SL rev:     "%s) grCardanoCommit
+  , ""
+  , format ("applicationVersion: "%d) grApplicationVersion
+  ]
+
+printInstallersResults :: InstallersResults -> IO ()
+printInstallersResults InstallersResults{..} = T.putStr $ T.unlines
+  [rule, formatVersionInfo globalResult, "", formatCIResults ciResults, rule]
+  where rule = "============================================================" :: T.Text
+
+data StatusContext = StatusContextAppveyor Appveyor.Username Appveyor.Project ApplicationVersion
                    | StatusContextBuildkite T.Text Int
                    deriving (Show, Eq)
 
@@ -399,60 +246,35 @@ parseStatusContext status = parseAppveyor <|> parseBuildKite
     isAppveyor = context status == "continuous-integration/appveyor/branch"
     isBuildkite = "buildkite/" `T.isPrefixOf` context status
 
-findInstaller :: HasCallStack => BK.APIToken -> T.Text -> T.Text -> T.Text -> (ApplicationVersionKey 'Win64, ApplicationVersionKey 'Mac64) -> Status -> IO (Maybe GlobalResults, Maybe CiResult)
-findInstaller buildkiteToken daedalus_rev daedalus_version tempdir keys status = do
+findInstallersFromStatus :: BK.APIToken -> FilePath -> InstallerPredicate -> Status -> IO [(Arch, CIResult)]
+findInstallersFromStatus buildkiteToken tempdir instP status =
   case parseStatusContext status of
-    Just (StatusContextBuildkite _repo buildNum) -> do
-      (globalResults, travisResult') <- processDarwinBuildKite buildkiteToken daedalus_rev daedalus_version tempdir buildNum keys (targetUrl status)
-      return (Just globalResults, Just travisResult')
-    Just (StatusContextAppveyor user project version) -> do
-      appveyorBuild <- fetchAppveyorBuild user project version
-      let jobid = appveyorBuild ^. build . Appveyor.jobs . to head . jobId
-      artifacts <- fetchAppveyorArtifacts jobid
-      case headMay artifacts of
-        Just (AppveyorArtifact filename "Daedalus Win64 Installer") -> do
-          let
-            artifactUrl = getArtifactUrl jobid filename
-            basename = head $ drop 1 $ T.splitOn "/" filename
-            outFile = tempdir <> "/" <> basename
-          putStr "appveyor URL: "
-          setSGR [ SetColor Foreground Dull Green ]
-          putStrLn $ T.unpack artifactUrl
-          setSGR [ Reset ]
-          fetchCachedUrl artifactUrl basename outFile
-          pure (Nothing, Just $ AppveyorResult outFile version (targetUrl status))
-        _ -> pure (Nothing, Nothing)
+    Just (StatusContextBuildkite _repo buildNum) ->
+      findInstallersBuildKite buildkiteToken tempdir instP buildNum (targetUrl status)
+    Just (StatusContextAppveyor user project version) ->
+      findInstallersAppVeyor tempdir instP (targetUrl status) user project version
     Nothing -> do
       putStrLn $ "unrecognized CI status: " <> T.unpack (context status)
-      pure (Nothing, Nothing)
+      pure []
 
 githubWikiRecord :: InstallersResults -> T.Text
-githubWikiRecord results = join [ T.pack $ show appVersion
-                                , ""
-                                , githubLink daedalus_rev "daedalus"
-                                , githubLink cardano_rev "cardano-sl"
-                                , ciLink buildkite
-                                , ciLink appvey
-                                , "DATE\n" ]
+githubWikiRecord InstallersResults{..} = T.intercalate " | " cols <> "\n"
   where
-    buildkiteDetails = buildkiteResult results
-    appveyorDetails = appveyorResult results
-    globalDetails = globalResult results
+    cols = [ format w $ grApplicationVersion globalResult
+           , ""
+           , githubLink grDaedalusCommit "daedalus"
+           , githubLink grCardanoCommit "cardano-sl"
+           , ciLink Mac64
+           , ciLink Win64
+           , "DATE" ]
 
-    appVersion = grApplicationVersion globalDetails
-    cardano_rev = grCardanoCommit globalDetails
-    daedalus_rev = grDaedalusCommit globalDetails
+    githubLink rev project = githubLink' (rev globalResult) project
+    githubLink' rev project = mdLink (T.take 6 rev) (format ("https://github.com/input-output-hk/"%s%"/commit/"%s) project rev)
 
-    appvey = liftA2 (,) (getApplicationVersion . avVersion <$> appveyorDetails) (avUrl <$> appveyorDetails)
-    buildkite = liftA2 (,) (T.pack . show . bkBuildNumber <$> buildkiteDetails) (bkUrl <$> buildkiteDetails)
+    ciLink arch = maybe "*missing*" ciLink' $ lookup arch ciResults
+    ciLink' CIResult{..} = mdLink (format d ciResultBuildNumber) ciResultUrl
 
-    githubLink rev project = "[" <> (T.take 6 rev) <> "](https://github.com/input-output-hk/" <> project <> "/commit/" <> rev <> ")"
-
-    ciLink :: Maybe (T.Text, T.Text) -> T.Text
-    ciLink (Just (num, url)) = "[" <> num <> "](" <> url <> ")"
-    ciLink Nothing = "*missing*"
-
-    join = T.intercalate " | "
+    mdLink = format ("["%s%"]("%s%")")
 
 updateVersionJson :: T.Text -> LBS.ByteString -> IO T.Text
 updateVersionJson bucket json = runAWS' . withinBucketRegion bucketName $ \region -> do

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -243,7 +243,10 @@ loadParams opts = do
   printf ("Loading update proposal parameters from "%w%"\n") yaml
   liftIO (decodeFileEither yaml) >>= \case
     Right cfg -> doCheckConfig cfg >> pure cfg
-    Left e -> die $ format ("Bad config: "%w%"\n") e
+    Left e ->
+      let msg = "Could not parse: "%w%"\n" %
+                "The update-proposal steps need to be run in order.\n"
+      in die $ format msg e
 
 storeParams :: ToJSON cfg => CommandOptions -> cfg -> Shell ()
 storeParams opts params = do

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -427,7 +427,8 @@ updateProposalFindInstallers opts env = do
   void $ doCheckConfig params
   echo "*** Finding installers"
   let rev = unGitRevision . cfgDaedalusRevision $ params
-  res <- using $ realFindInstallers (configurationKeys env) (installerForEnv env) rev
+  tempdir <- mktempdir "/tmp" "iohk-ops"
+  res <- liftIO $ realFindInstallers (configurationKeys env) (installerForEnv env) rev (Just tempdir)
   echo "*** Finished. Moving files to work dir"
   res' <- moveInstallersToWorkDir opts res
   writeWikiRecord opts res'

--- a/iohk/Utils.hs
+++ b/iohk/Utils.hs
@@ -6,6 +6,7 @@
 
 module Utils where
 
+import           Prelude                   hiding (FilePath)
 import           Data.Aeson                (FromJSON, decode)
 import qualified Data.ByteString.Lazy      as LBS
 import           Data.Monoid               ((<>))
@@ -18,7 +19,6 @@ import           Network.HTTP.Client       (httpLbs, parseRequest,
 import           Network.HTTP.Client.TLS   (newTlsManager)
 import           Network.HTTP.Types.Header (RequestHeaders)
 import           System.Exit               (ExitCode (ExitFailure, ExitSuccess))
-import           Turtle.Prelude            (proc)
 import qualified Data.Aeson                    as AE
 import qualified Data.Aeson.Types              as AE
 import qualified Data.Char                     as C
@@ -29,18 +29,18 @@ import           Network.AWS               (Region)
 import           Network.AWS.S3            (BucketName(..), ObjectKey(..))
 import qualified Network.AWS.Data          as AWS
 
-fetchCachedUrl :: HasCallStack => T.Text -> T.Text -> T.Text-> IO ()
+fetchCachedUrl :: HasCallStack => T.Text -> FilePath -> FilePath -> IO ()
 fetchCachedUrl url name outPath = fetchCachedUrl' url name outPath Nothing
 
-fetchCachedUrlWithSHA1 :: HasCallStack => T.Text -> T.Text -> T.Text -> T.Text -> IO ()
+fetchCachedUrlWithSHA1 :: HasCallStack => T.Text -> FilePath -> FilePath -> T.Text -> IO ()
 fetchCachedUrlWithSHA1 url name outPath sha1 = fetchCachedUrl' url name outPath (Just sha1)
 
-fetchCachedUrl' :: HasCallStack => T.Text -> T.Text -> T.Text -> Maybe T.Text -> IO ()
+fetchCachedUrl' :: HasCallStack => T.Text -> FilePath -> FilePath -> Maybe T.Text -> IO ()
 fetchCachedUrl' url name outPath sha1 = proc "nix-build" args mempty >>= handleExit
   where
-    args = [ "-E", "with import <nixpkgs> {}; let file = " <> fetchExpr <> "; in runCommand \"" <> name <> "\" {} \"ln -sv ${file} $out\"", "-o", outPath ]
+    args = [ "-E", format ("with import <nixpkgs> {}; let file = "%s%"; in runCommand \""%fp%"\" {} \"ln -sv ${file} $out\"") fetchExpr name, "-o", format fp outPath ]
     fetchExpr = case sha1 of
-      Just hash -> "pkgs.fetchurl { url = \"" <> url <> "\"; sha1 = \"" <> hash <> "\"; }"
+      Just hash -> format ("pkgs.fetchurl { url = \""%s%"\"; sha1 = \""%s%"\"; }") url hash
       Nothing   -> "builtins.fetchurl \"" <> url <> "\""
     handleExit ExitSuccess     = return ()
     handleExit (ExitFailure _) = error "error downloading file"
@@ -98,6 +98,9 @@ lowerShowT = T.toLower . T.pack . show
 
 errorT :: Text -> a
 errorT = error . T.unpack
+
+tt :: FilePath -> Text
+tt = format fp
 
 -- Currently unused, but that's mere episode of the used/unused/used/unused event train.
 -- Let's keep it, because it's too painful to reinvent every time we need it.

--- a/iohk/default.nix
+++ b/iohk/default.nix
@@ -1,10 +1,10 @@
 { mkDerivation, aeson, aeson-pretty, amazonka, amazonka-s3
 , ansi-terminal, base, bytestring, cassava, containers, cryptonite
-, directory, dns, errors, git, hourglass, hspec, http-client
-, http-client-tls, http-conduit, http-types, lens, lens-aeson
-, managed, memory, mtl, network-uri, optional-args
+, directory, dns, errors, exceptions, foldl, git, hourglass, hspec
+, http-client, http-client-tls, http-conduit, http-types, lens
+, lens-aeson, managed, memory, mtl, network-uri, optional-args
 , optparse-applicative, regex-pcre, resourcet, safe, stdenv
-, system-filepath, text, turtle, universum, unix
+, system-filepath, text, time, turtle, universum, unix
 , unordered-containers, utf8-string, vector, yaml
 }:
 mkDerivation {
@@ -15,17 +15,19 @@ mkDerivation {
   isExecutable = true;
   executableHaskellDepends = [
     aeson aeson-pretty amazonka amazonka-s3 ansi-terminal base
-    bytestring cassava containers cryptonite directory dns errors git
-    hourglass http-client http-client-tls http-conduit http-types lens
-    lens-aeson managed memory mtl network-uri optional-args
-    optparse-applicative regex-pcre resourcet safe system-filepath text
-    turtle unix unordered-containers utf8-string vector yaml
+    bytestring cassava containers cryptonite directory dns errors
+    exceptions foldl git hourglass http-client http-client-tls
+    http-conduit http-types lens lens-aeson managed memory mtl
+    network-uri optional-args optparse-applicative regex-pcre resourcet
+    safe system-filepath text time turtle unix unordered-containers
+    utf8-string vector yaml
   ];
   testHaskellDepends = [
     aeson amazonka amazonka-s3 ansi-terminal base bytestring cassava
-    cryptonite directory errors git hspec http-client http-client-tls
-    http-conduit http-types lens managed memory network-uri regex-pcre
-    resourcet safe system-filepath text turtle universum
+    containers cryptonite directory errors exceptions foldl git
+    hourglass hspec http-client http-client-tls http-conduit http-types
+    lens lens-aeson managed memory network-uri regex-pcre resourcet
+    safe system-filepath text time turtle universum
     unordered-containers yaml
   ];
   license = stdenv.lib.licenses.bsd3;

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -31,6 +31,7 @@ executable iohk-ops
                      , cassava >=0.4
                      , containers >=0.5
                      , dns
+                     , exceptions
                      , hourglass
                      , lens >=4.14
                      , lens-aeson >=1.0
@@ -96,6 +97,7 @@ test-suite iohk-ops-test
                   , network-uri
                   , cryptonite
                   , errors
+                  , exceptions
                   , memory
                   , regex-pcre
                   , time

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -100,4 +100,7 @@ test-suite iohk-ops-test
                   , regex-pcre
                   , time
                   , foldl
+                  , hourglass
+                  , containers
+                  , lens-aeson
   hs-source-dirs:   test .


### PR DESCRIPTION
* Versions and commit ids are now found by using nix.

* It now supports downloading of both staging and mainnet installers (DEVOPS-690).

* iohk-ops find-installers now prints a handy summary when finished ([example](https://github.com/input-output-hk/internal-documentation/wiki/iohk-ops-reference#find-installers)).

* Actually downloading the files is now optional in iohk-ops find-installers.

* Moved s3upload command into subcommand of update-proposal.

* It should be fairly simple now to add Linux installer support (DEVOPS-13).

* Straightened out the data types a little bit.

* Split out the code related to getting Daedalus installer version info into its own module.

* Some churn with converting some values to FilePath type.
