### PR TITLE
[DEVOPS-794] Add inodes monitor for mainnet and staging clusters

### DIFF
--- a/deployments/cardano-nodes-env-production.nix
+++ b/deployments/cardano-nodes-env-production.nix
@@ -11,6 +11,7 @@ let nodeMap = globals.nodeMap; in
     datadogMonitors = (with (import ./../modules/datadog-monitors.nix); {
       cpu = mkMonitor cpu_monitor;
       disk = mkMonitor (disk_monitor "!host:mainnet.ec2.report-server" "0.8" "0.9");
+      inodes = mkMonitor (inodes_monitor 7 2);
       ram = mkMonitor ram_monitor;
       ntp = mkMonitor ntp_monitor;
       cardano_node_simple_process = mkMonitor cardano_node_simple_process_monitor;

--- a/deployments/cardano-nodes-env-staging.nix
+++ b/deployments/cardano-nodes-env-staging.nix
@@ -22,6 +22,9 @@ let nodeMap = globals.nodeMap; in
       disk = mkMonitor (disk_monitor "!host:rc-staging.ec2.report-server" "0.8" "0.9" // {
         message = pagerDutyPolicy.nonCritical;
       });
+      inodes = mkMonitor (inodes_monitor 7 2 // {
+        message = pagerDutyPolicy.nonCritical;
+      });
       ram = mkMonitor (ram_monitor // {
         message = pagerDutyPolicy.nonCritical;
       });

--- a/modules/datadog-monitors.nix
+++ b/modules/datadog-monitors.nix
@@ -75,6 +75,20 @@ rec {
     };
   };
 
+  inodes_monitor = warningDays: criticalDays: let
+    inodes = days: 2160 * 2 * 2;  # 2 files per block, 24 hours of blocks.
+    warning = inodes warningDays;
+    critical = inodes criticalDays;
+  in {
+    name = "Low available inodes";
+    type = "metric alert";
+    query = config: "max(last_5m):avg:system.fs.inodes.free{depl:${config.deployment.name}} by {host,device} < ${toString critical}";
+    monitorOptions.thresholds = {
+      warning = "${toString warning}";
+      critical = "${toString critical}";
+    };
+  };
+
   ram_monitor = {
     name = "RAM is running low";
     type = "metric alert";


### PR DESCRIPTION
So far tested only by building the nixops network.
Can anyone suggest a good way of testing that doesn't involve deploying to staging?
