### PR TITLE
Adding mantis-iele-ops to the hydra jobsets.

### DIFF
--- a/jobsets/default-mantis.nix
+++ b/jobsets/default-mantis.nix
@@ -29,7 +29,7 @@ let
     nixexprinput = "mantis";
     description = "Mantis";
     inputs = {
-      mantis = mkFetchGithub "https://github.com/input-output-hk/mantis-iele-ops.git ${mantisBranch}";
+      mantis = mkFetchGithub "https://github.com/input-output-hk/mantis.git ${mantisBranch}";
     };
   };
   mainJobsets = with pkgs.lib; mapAttrs (name: settings: defaultSettings // settings) (rec {

--- a/jobsets/default-mantis.nix
+++ b/jobsets/default-mantis.nix
@@ -1,0 +1,47 @@
+{ nixpkgs ? <nixpkgs>
+, declInput ? {}
+}:
+
+# Followed by https://github.com/NixOS/hydra/pull/418/files
+
+let
+  mkFetchGithub = value: {
+    inherit value;
+    type = "git";
+    emailresponsible = false;
+  };
+  nixpkgs-src = builtins.fromJSON (builtins.readFile ./../nixpkgs-src.json);
+  pkgs = import nixpkgs {};
+  defaultSettings = {
+    enabled = 1;
+    hidden = false;
+    nixexprinput = "jobsets";
+    keepnr = 5;
+    schedulingshares = 42;
+    checkinterval = 60;
+    inputs = {
+    };
+    enableemail = false;
+    emailoverride = "";
+  };
+  mkMantis = mantisBranch: {
+    nixexprpath = "jobsets/release.nix";
+    nixexprinput = "mantis";
+    description = "Mantis";
+    inputs = {
+      mantis = mkFetchGithub "https://github.com/input-output-hk/mantis-iele-ops.git ${mantisBranch}";
+    };
+  };
+  mainJobsets = with pkgs.lib; mapAttrs (name: settings: defaultSettings // settings) (rec {
+    mantis-testnet = mkMantis "phase/iele_testnet";
+  });
+  jobsetsAttrs = mainJobsets;
+  jobsetJson = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);
+in {
+  jobsets = with pkgs.lib; pkgs.runCommand "spec.json" {} ''
+    cat <<EOF
+    ${builtins.toJSON declInput}
+    EOF
+    cp ${jobsetJson} $out
+  '';
+}

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -94,14 +94,6 @@ let
       };
     };
   };
-  mkMantis = mantisBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "mantis";
-    description = "Mantis";
-    inputs = {
-      mantis = mkFetchGithub "https://github.com/input-output-hk/mantis-iele-ops.git ${mantisBranch}";
-    };
-  };
   nixopsPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeNixopsPR nixopsPrs);
   cardanoPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeCardanoPR cardanoPrs);
   daedalusPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeDaedalusPR daedalusPrs);
@@ -111,7 +103,6 @@ let
     cardano-sl-1-0 = mkCardano "release/1.0.x";
     cardano-sl-1-2 = mkCardano "release/1.2.0";
     daedalus = mkDaedalus "develop";
-    mantis-testnet = mkMantis "phase/iele_testnet";
     iohk-nixops = mkNixops "master" nixpkgs-src.rev;
     iohk-nixops-staging = mkNixops "staging" nixpkgs-src.rev;
   });

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -94,6 +94,14 @@ let
       };
     };
   };
+  mkMantis = mantisBranch: {
+    nixexprpath = "release.nix";
+    nixexprinput = "mantis";
+    description = "Mantis";
+    inputs = {
+      mantis = mkFetchGithub "https://github.com/input-output-hk/mantis-iele-ops.git ${mantisBranch}";
+    };
+  };
   nixopsPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeNixopsPR nixopsPrs);
   cardanoPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeCardanoPR cardanoPrs);
   daedalusPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeDaedalusPR daedalusPrs);
@@ -103,10 +111,11 @@ let
     cardano-sl-1-0 = mkCardano "release/1.0.x";
     cardano-sl-1-2 = mkCardano "release/1.2.0";
     daedalus = mkDaedalus "develop";
+    mantis-testnet = mkMantis "phase/iele_testnet";
     iohk-nixops = mkNixops "master" nixpkgs-src.rev;
     iohk-nixops-staging = mkNixops "staging" nixpkgs-src.rev;
   });
-  jobsetsAttrs =  daedalusPrJobsets // nixopsPrJobsets // (if handleCardanoPRs then cardanoPrJobsets else {}) // mainJobsets;
+  jobsetsAttrs = daedalusPrJobsets // nixopsPrJobsets // (if handleCardanoPRs then cardanoPrJobsets else {}) // mainJobsets;
   jobsetJson = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);
 in {
   jobsets = with pkgs.lib; pkgs.runCommand "spec.json" {} ''

--- a/jobsets/spec-mantis.json
+++ b/jobsets/spec-mantis.json
@@ -3,13 +3,14 @@
     "hidden": false,
     "description": "Jobsets",
     "nixexprinput": "src",
-    "nixexprpath": "jobsets/default.nix",
+    "nixexprpath": "jobsets/default-mantis.nix",
     "checkinterval": 60,
     "schedulingshares": 420,
     "enableemail": true,
     "emailoverride": "",
     "keepnr": 3,
     "inputs": {
-         "src": { "type": "git", "value": "https://github.com/input-output-hk/mantis.git hydra-config", "emailresponsible": false }
+         "src": { "type": "git", "value": "https://github.com/input-output-hk/iohk-ops.git develop", "emailresponsible": false }
+        ,"nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs-channels.git nixos-18.03", "emailresponsible": false }
      }
 }

--- a/jobsets/spec-mantis.json
+++ b/jobsets/spec-mantis.json
@@ -1,0 +1,15 @@
+{
+    "enabled": 1,
+    "hidden": false,
+    "description": "Jobsets",
+    "nixexprinput": "src",
+    "nixexprpath": "jobsets/default-mantis.nix",
+    "checkinterval": 60,
+    "schedulingshares": 420,
+    "enableemail": true,
+    "emailoverride": "",
+    "keepnr": 3,
+    "inputs": {
+         "src": { "type": "git", "value": "https://github.com/input-output-hk/iohk-ops.git develop", "emailresponsible": false }
+     }
+}

--- a/jobsets/spec-mantis.json
+++ b/jobsets/spec-mantis.json
@@ -3,13 +3,13 @@
     "hidden": false,
     "description": "Jobsets",
     "nixexprinput": "src",
-    "nixexprpath": "jobsets/default-mantis.nix",
+    "nixexprpath": "jobsets/default.nix",
     "checkinterval": 60,
     "schedulingshares": 420,
     "enableemail": true,
     "emailoverride": "",
     "keepnr": 3,
     "inputs": {
-         "src": { "type": "git", "value": "https://github.com/input-output-hk/iohk-ops.git develop", "emailresponsible": false }
+         "src": { "type": "git", "value": "https://github.com/input-output-hk/mantis.git hydra-config", "emailresponsible": false }
      }
 }


### PR DESCRIPTION
This adds the following JSON stanza to the jobset definition:

>   "mantis-testnet": {
>     "checkinterval": 60,
>     "description": "Mantis",
>     "emailoverride": "",
>     "enabled": 1,
>     "enableemail": false,
>     "hidden": false,
>     "inputs": {
>       "mantis": {
>         "emailresponsible": false,
>         "type": "git",
>         "value": "https://github.com/input-output-hk/mantis-iele-ops.git phase/iele_testnet"
>       }
>     },
>     "keepnr": 5,
>     "nixexprinput": "mantis",
>     "nixexprpath": "release.nix",
>     "schedulingshares": 42
>   },