### PR TITLE
[DEVOPS-833] buildkite CI: fix build failing with "exit status 123"

### DIFF
--- a/scripts/find-all-revisions.sh
+++ b/scripts/find-all-revisions.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-find . -type f '!' -path '*/.git/*' '!' -path ./pkgs/default.nix -print0 | xargs -0 egrep --color '[^a-z0-9][a-z0-9]{40}[^a-z0-9]'
-
+git ls-files | grep -v pkgs/default.nix | xargs grep -EH --color '[^a-z0-9][a-z0-9]{40}[^a-z0-9]'
+exit 0


### PR DESCRIPTION
Apparently due to xargs, thanks to @365andreas for finding it.

https://stackoverflow.com/questions/26540813/got-exit-code-123-in-find-xargs-grep

This change also makes the grep run faster when executed locally in a dirty git checkout.