### PR TITLE
[DEVOPS-823] report-server: rotate index.log every 20MB

### DIFF
--- a/deployments/report-server-bucket-storage.nix
+++ b/deployments/report-server-bucket-storage.nix
@@ -3,16 +3,30 @@
 {
   # this file will create an S3 bucket, and IAM role with access to that bucket
   # then give the report-server machine access to that role, and mount the bucket within the instance
-  report-server = { pkgs, resources, ... }: {
+  report-server = { pkgs, config, resources, ... }:
+  let logsdir = config.services.report-server.logsdir;
+  in {
     # nixops can only set this at creation, it will need to be manualy set
     deployment.ec2.instanceProfile = resources.iamRoles.report-role.name;
-    fileSystems."/var/lib/report-server" = {
+    fileSystems.${logsdir} = {
       # mount unsets PATH when running this
       device = "/run/current-system/sw/bin/s3fs#${resources.s3Buckets.report-server-logs.name}";
       fsType = "fuse";
       options = [ "_netdev" "allow_other" ("iam_role=${resources.iamRoles.report-role.name}") ];
     };
     environment.systemPackages = [ pkgs.s3fs ];
+    # S3 is bad at appending to files, and it gets worse the larger
+    # they are. So limit report-server's log to 20MB. NixOS runs this
+    # daily at 5AM.
+    services.logrotate.enable = true;
+    services.logrotate.config = ''
+      ${logsdir}/index.log {
+        size 20M
+        compress
+        dateext
+        rotate 10000
+      }
+    '';
   };
   resources = {
     s3Buckets = {


### PR DESCRIPTION
Have tested this with a slightly modified developer cluster.
```
nixops ssh -d devops-823 ssh report-server
dd if=/dev/zero bs=1M count=21 of=/var/lib/report-server/index.log
systemctl start logrotate
ls -l /var/lib/report-server
mv /var/lib/report-server/index.log-20180515.gz  /var/lib/report-server/index.log-20180514.gz
dd if=/dev/zero bs=1M count=21 of=/var/lib/report-server/index.log
systemctl start logrotate
ls -l /var/lib/report-server
```

Results:
```
[root@devops-823:~]# ls -l /var/lib/report-server/
total 48
-rw-r--r-- 1 report-server report-server 21397 May 15 08:53 index.log-20180514.gz
-rw-r--r-- 1 root          root          21397 May 15 08:55 index.log-20180515.gz
```
