### PR TITLE
[DEVOPS-794] Fix inodes available monitor

### DIFF
--- a/modules/datadog-monitors.nix
+++ b/modules/datadog-monitors.nix
@@ -76,16 +76,15 @@ rec {
   };
 
   inodes_monitor = warningDays: criticalDays: let
-    inodes = days: 2160 * 2 * 2;  # 2 files per block, 24 hours of blocks.
+    inodes = days: 2160 * 2 * 2 * days;  # 2 files per block, 24 hours of blocks.
     warning = inodes warningDays;
     critical = inodes criticalDays;
   in {
     name = "Low available inodes";
     type = "metric alert";
-    query = config: "max(last_5m):avg:system.fs.inodes.free{depl:${config.deployment.name}} by {host,device} < ${toString critical}";
+    query = config: "min(last_1m):avg:system.fs.inodes.free{depl:${config.deployment.name}} by {host,device} < ${toString critical}";
     monitorOptions.thresholds = {
-      warning = "${toString warning}";
-      critical = "${toString critical}";
+      inherit warning critical;
     };
   };
 


### PR DESCRIPTION
Found the cause of "Warning threshold must be greater than critical with < comparison" error was my blindness. Now the monitor can actually be deployed.
