### PR TITLE
patch hydra to return 404 instead of 410

### DIFF
--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -27,6 +27,7 @@ let
       patches = [
         ./chomp.patch
         ./hydra-nix-prefetch-git.patch
+        ./hydra-not-found.patch
       ];
     });
   };

--- a/modules/hydra-not-found.patch
+++ b/modules/hydra-not-found.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/Hydra/Controller/Root.pm b/src/lib/Hydra/Controller/Root.pm
+index 234f73f4..0aae2c54 100644
+--- a/src/lib/Hydra/Controller/Root.pm
++++ b/src/lib/Hydra/Controller/Root.pm
+@@ -266,7 +266,7 @@ sub nar :Local :Args(1) {
+     else {
+         $path = $Nix::Config::storeDir . "/$path";
+ 
+-        gone($c, "Path " . $path . " is no longer available.") unless isValidPath($path);
++        notFound($c, "Path " . $path . " is no longer available.") unless isValidPath($path);
+ 
+         $c->stash->{current_view} = 'NixNAR';
+         $c->stash->{storePath} = $path;


### PR DESCRIPTION
this should prevent the 410 gone errors happening in CI