### PR TITLE
[DEVOPS-836] configure hydra to upload everything to S3

### DIFF
--- a/modules/hydra-master.nix
+++ b/modules/hydra-master.nix
@@ -77,8 +77,13 @@ in {
     # auth token needs `repo:status`
     extraConfig = ''
       max_output_size = 4294967296
-      store-uri = file:///nix/store?secret-key=/etc/nix/hydra.iohk.io-1/secret
-      binary_cache_secret_key_file = /etc/nix/hydra.iohk.io-1/secret
+
+      store_uri = s3://iohk-nix-cache?secret-key=/etc/nix/hydra.iohk.io-1/secret&log-compression=br&region=eu-central-1
+      server_store_uri = https://iohk-nix-cache.s3-eu-central-1.amazonaws.com/
+      binary_cache_public_uri = https://iohk-nix-cache.s3-eu-central-1.amazonaws.com/
+      log_prefix = https://iohk-nix-cache.s3-eu-central-1.amazonaws.com/
+      upload_logs_to_binary_cache = true
+
       <github_authorization>
         input-output-hk = ${builtins.readFile ../static/github_token}
       </github_authorization>
@@ -184,6 +189,9 @@ in {
           proxy_set_header REMOTE_ADDR $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto https;
+        }
+        location ~ /(nix-cache-info|.*\.narinfo|nar/*) {
+          return 301 https://iohk-nix-cache.s3-eu-central-1.amazonaws.com$request_uri;
         }
       }
     '';


### PR DESCRIPTION
this PR configures hydra to upload all artifacts to the S3 bucket iohk-nix-cache
it relies on an IAM user that has S3 access to the bucket
and the access keyid/secret have to be configured in /var/lib/hydra/queue-runner/.aws/credentials
that can be automated with the following commands

```
sudo -u hydra-queue-runner -i
nix run nixpkgs.awscli
aws configure
```

the PR also handles redirections of binary-cache files from hydra.iohk.io to https://iohk-nix-cache.s3-eu-central-1.amazonaws.com

