### PR TITLE
[DEVOPS-881] fix NTP crashing due to openat syscall

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -5,6 +5,7 @@ with (import ./../lib.nix);
 let
   iohk-pkgs = import ../default.nix {};
 in {
+  imports = [ ./ntp_fix.nix ];
   boot.kernel.sysctl = {
     ## DEVOPS-592
     "kernel.unprivileged_bpf_disabled" = 1;

--- a/modules/ntp_fix.nix
+++ b/modules/ntp_fix.nix
@@ -1,0 +1,9 @@
+let
+  overlay = self: super: {
+    ntp = super.ntp.overrideAttrs (drv: {
+      patches = drv.patches or [] ++ [ ./openat.patch ];
+    });
+  };
+in {
+  nixpkgs.overlays = [ overlay ];
+}

--- a/modules/openat.patch
+++ b/modules/openat.patch
@@ -1,0 +1,11 @@
+diff -ur ntp-4.2.8p10-orig/ntpd/ntpd.c ntp-4.2.8p10/ntpd/ntpd.c
+--- ntp-4.2.8p10-orig/ntpd/ntpd.c	2018-06-07 08:55:59.677037920 -0300
++++ ntp-4.2.8p10/ntpd/ntpd.c	2018-06-07 08:56:15.588286903 -0300
+@@ -1182,6 +1182,7 @@
+ 	SCMP_SYS(setitimer),
+ 	SCMP_SYS(setsid),
+         SCMP_SYS(setsockopt),
++        SCMP_SYS(openat),
+ 	SCMP_SYS(socket),
+ 	SCMP_SYS(stat),
+ 	SCMP_SYS(time),


### PR DESCRIPTION
this continues ths fix from https://github.com/NixOS/nixpkgs/pull/24573
the above PR likely missed the `openat` syscall due to it not opening the drift compensation file for several hours