### PR TITLE
[DEVOPS-903] Bump cardano-sl to 1.2.0 tagged version

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
     "url": "https://github.com/input-output-hk/cardano-sl",
     "fetchSubmodules": "true",
-    "sha256": "03lfjbs1j8y2m49bbcadr47mld9hk27ijznb2x6m4zh2k3zl4wps",
-    "rev": "55dce875afa9eb931fb4253a1d6c0bfca489b2cb"
+    "sha256": "0n0r41pyiky8q1lsdqnkcaq9zrn8azjngi5q8298999lsxfjj98w",
+    "rev": "bfbcda3d9c733198d7f683cbb93a77a495d96f68"
 }


### PR DESCRIPTION
Previous rev is a few commits behind and pretty much the same, except for the ChangeLog. But it's best to deploy the exact revision tagged with 1.2.0.