### PR TITLE
[DEVOPS-788] Add support for finding Linux installers from CI

### DIFF
--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -905,10 +905,12 @@ date o c = parallelIO o c $
   (\out -> TIO.putStrLn $ fromNodeName n <> ": " <> out)
 
 configurationKeys :: Environment -> Arch -> T.Text
-configurationKeys Production Win64 = "mainnet_wallet_win64"
-configurationKeys Production Mac64 = "mainnet_wallet_macos64"
-configurationKeys Staging    Win64 = "mainnet_dryrun_wallet_win64"
-configurationKeys Staging    Mac64 = "mainnet_dryrun_wallet_macos64"
+configurationKeys Production Win64   = "mainnet_wallet_win64"
+configurationKeys Production Mac64   = "mainnet_wallet_macos64"
+configurationKeys Production Linux64 = "mainnet_wallet_linux64"
+configurationKeys Staging    Win64   = "mainnet_dryrun_wallet_win64"
+configurationKeys Staging    Mac64   = "mainnet_dryrun_wallet_macos64"
+configurationKeys Staging    Linux64 = "mainnet_dryrun_wallet_linux64"
 configurationKeys env _ = error $ "Application versions not used in '" <> show env <> "' environment"
 
 findInstallers :: NixopsConfig -> T.Text -> Maybe FilePath -> IO ()

--- a/iohk/UpdateLogic.hs
+++ b/iohk/UpdateLogic.hs
@@ -41,13 +41,13 @@ import           Control.Applicative          ((<|>))
 import           Control.Exception            (try)
 import           Control.Lens                 (to, (^.))
 import qualified Control.Lens                 as Lens
-import           Control.Monad                (guard, forM, when)
-import           Control.Monad.Managed        (Managed, liftIO)
+import           Control.Monad                (guard, when, (<=<))
+import           Control.Monad.IO.Class       (liftIO)
 import           Control.Monad.Trans.Resource (runResourceT)
 import           Data.Aeson                   (ToJSON, FromJSON)
 import qualified Data.ByteString.Lazy         as LBS
 import qualified Data.HashMap.Strict          as HashMap
-import           Data.List                    (nub)
+import           Data.List                    (nub, find)
 import           Data.Maybe                   (fromMaybe, isJust)
 import           Data.Monoid                  ((<>))
 import qualified Data.Text                    as T
@@ -83,25 +83,32 @@ import           Filesystem.Path              (FilePath, (</>), filename)
 
 import           InstallerVersions
 import           Types                        (ApplicationVersion, ApplicationVersionKey,
-                                               Arch (Mac64, Win64), formatArch)
+                                               Arch (Linux64, Mac64, Win64), formatArch)
 import           Utils                        (fetchCachedUrl, fetchCachedUrlWithSHA1, s3Link)
 
 data CIResult = CIResult
-  { ciResultLocalPath   :: FilePath
+  { ciResultSystem      :: CISystem
+  , ciResultLocalPath   :: FilePath
   , ciResultUrl         :: Text
   , ciResultDownloadUrl :: Text
   , ciResultBuildNumber :: Int
+  , ciResultArch        :: Arch
+  , ciResultSHA1Sum     :: Maybe Text
   } deriving (Show, Generic)
 
+data CISystem = Buildkite | AppVeyor deriving (Show, Generic)
+
 data InstallersResults = InstallersResults
-  { ciResults    :: [(Arch, CIResult)]
+  { ciResults    :: [CIResult]
   , globalResult :: GlobalResults
   } deriving (Show, Generic)
 
 instance FromJSON InstallersResults
 instance FromJSON CIResult
+instance FromJSON CISystem
 instance ToJSON InstallersResults
 instance ToJSON CIResult
+instance ToJSON CISystem
 
 -- | Allow selection of which CI artifacts to download.
 type InstallerPredicate = CIResult -> Bool
@@ -130,89 +137,98 @@ realFindInstallers keys instP daedalusRev destDir = do
   buildkiteToken <- liftIO $ loadBuildkiteToken
   globalResult <- liftIO $ findVersionInfo keys daedalusRev
   st <- liftIO $ statuses <$> fetchGithubStatus "input-output-hk" "daedalus" daedalusRev
-  results <- liftIO $ concat <$> mapM (findInstallersFromStatus buildkiteToken destDir instP) st
-  pure $ InstallersResults results globalResult
+  results <- mapM (handleCIResults instP destDir <=< findInstallersFromStatus buildkiteToken destDir) st
+  pure $ InstallersResults (concat results) globalResult
+
+handleCIResults :: InstallerPredicate -> Maybe FilePath -> Either Text [CIResult] -> IO [CIResult]
+handleCIResults instP destDir (Right rs) = do
+  let rs' = filter instP rs
+  when (isJust destDir) $ fetchCIResults rs'
+  pure rs'
+handleCIResults _ _ (Left msg) = T.putStrLn msg >> pure []
 
 buildkiteOrg     = "input-output-hk" :: Text
 pipelineDaedalus = "daedalus"        :: Text
 
-bkArtifactIsInstaller :: Artifact -> Bool
-bkArtifactIsInstaller = T.isSuffixOf ".pkg" . artifactFilename
+bkArtifactInstallerArch :: Artifact -> Maybe Arch
+bkArtifactInstallerArch art | T.isSuffixOf ".pkg" fn = Just Mac64
+                            | T.isSuffixOf ".bin" fn = Just Linux64
+                            | otherwise = Nothing
+  where fn = artifactFilename art
 
-findInstallersBuildKite :: APIToken -> Maybe FilePath -> InstallerPredicate -> Int -> Text -> IO [(Arch, CIResult)]
-findInstallersBuildKite apiToken destDir instP buildNum buildUrl = do
+findInstallersBuildKite :: APIToken -> Maybe FilePath -> Int -> T.Text
+                        -> IO (Either Text [CIResult])
+findInstallersBuildKite apiToken destDir buildNum buildUrl = do
   let buildDesc = format ("Buildkite build #"%d) buildNum
   arts <- listArtifactsForBuild apiToken buildkiteOrg pipelineDaedalus buildNum
-
-  rs <- forInstallers buildDesc bkArtifactIsInstaller arts $ \art -> do
+  let arts' = [ (art, arch) | (art, Just arch) <- [ (art, bkArtifactInstallerArch art) | art <- arts ] ]
+  forInstallers buildDesc (const True) arts' $ \(art, arch) -> do
     -- ask Buildkite what the download URL is
     url <- BK.getArtifactURL apiToken buildkiteOrg pipelineDaedalus buildNum art
-
     let out = fromMaybe "." destDir </> FP.fromText (artifactFilename art)
-        res = CIResult out buildUrl url buildNum
-    printCIResult "Buildkite" Mac64 res
-    pure (res, artifactSha1sum art)
-
-  forM (filter (instP . fst) rs) $ \(res, sha1) -> do
-    when (isJust destDir) $
-      -- download artifact into nix store
-      let out = ciResultLocalPath res
-      in fetchCachedUrlWithSHA1 (ciResultDownloadUrl res) (filename out) out sha1
-    pure (Mac64, res)
+    pure $ CIResult Buildkite out buildUrl url buildNum arch (Just $ artifactSha1sum art)
 
 avArtifactIsInstaller :: AppveyorArtifact -> Bool
 avArtifactIsInstaller (AppveyorArtifact _ name) = name == "Daedalus Win64 Installer"
 
-findInstallersAppVeyor :: Maybe FilePath -> InstallerPredicate -> Text
+findInstallersAppVeyor :: Maybe FilePath -> Text
                        -> Appveyor.Username -> Appveyor.Project -> ApplicationVersion
-                       -> IO [(Arch, CIResult)]
-findInstallersAppVeyor destDir instP url user project version = do
+                       -> IO (Either Text [CIResult])
+findInstallersAppVeyor destDir url user project version = do
   appveyorBuild <- fetchAppveyorBuild user project version
   let jobid = appveyorBuild ^. build . Appveyor.jobs . to head . jobId
       jobDesc = format ("AppVeyor job "%s) (unJobId jobid)
   artifacts <- fetchAppveyorArtifacts jobid
-  rs <- forInstallers jobDesc avArtifactIsInstaller artifacts $ \(AppveyorArtifact art _) ->
+  forInstallers jobDesc avArtifactIsInstaller artifacts $ \(AppveyorArtifact art _) ->
     pure CIResult
-      { ciResultLocalPath   = fromMaybe "." destDir </> filename (FP.fromText art)
+      { ciResultSystem      = AppVeyor
+      , ciResultLocalPath   = fromMaybe "." destDir </> filename (FP.fromText art)
       , ciResultUrl         = url
       , ciResultDownloadUrl = getArtifactUrl jobid art
       , ciResultBuildNumber = appveyorBuild ^. build . buildNumber . to unBuildNumber
+      , ciResultArch        = Win64
+      , ciResultSHA1Sum     = Nothing
       }
 
-  forM (filter instP rs) $ \res -> do
-    printCIResult "AppVeyor" Win64 res
-    when (isJust destDir) $
-      let out = ciResultLocalPath res
-      in fetchCachedUrl (ciResultDownloadUrl res) (filename out) out
-    pure (Win64, res)
+-- | Download artifacts into the nix store.
+fetchCIResults :: [CIResult] -> IO ()
+fetchCIResults = mapM_ fetchResult
+  where
+    fetchResult CIResult{..} = fetchCached ciResultDownloadUrl (filename ciResultLocalPath) ciResultLocalPath
+      where fetchCached = case ciResultSHA1Sum of
+                            Just sha1 -> fetchCachedUrlWithSHA1 sha1
+                            Nothing -> fetchCachedUrl
 
-forInstallers :: Text -> (a -> Bool) -> [a] -> (a -> IO b) -> IO [b]
+forInstallers :: Text -> (a -> Bool) -> [a] -> (a -> IO CIResult) -> IO (Either Text [CIResult])
 forInstallers job p arts action = case filter p arts of
-  [] -> die $ if null arts
+  [] -> pure $ Left $ if null arts
     then "No artifacts for " <> job
     else "Installer package file not found in artifacts of " <> job
-  files -> mapM action files
+  files -> Right <$> mapM showResult files
+    where showResult a = do
+            b <- action a
+            printCIResult b
+            pure b
 
-printCIResult :: Text -> Arch -> CIResult -> IO ()
-printCIResult ci arch CIResult{..} = do
-  printf (s%" "%w%" URL: ") ci arch
+printCIResult :: CIResult -> IO ()
+printCIResult CIResult{..} = do
+  printf (w%" "%w%" URL: ") ciResultSystem ciResultArch
   setSGR [ SetColor Foreground Dull Green ]
   T.putStrLn ciResultUrl
   setSGR [ Reset ]
 
-  printf (s%" "%w%" Installer: ") ci arch
+  printf (w%" "%w%" Installer: ") ciResultSystem ciResultArch
   setSGR [ SetColor Foreground Dull Green ]
   T.putStrLn ciResultDownloadUrl
   setSGR [ Reset ]
 
-formatCIResults :: [(Arch, CIResult)] -> Text
+formatCIResults :: [CIResult] -> Text
 formatCIResults rs = T.unlines $ ["CI links:"] ++ ciLinks ++ [""] ++ instLinks InstallerMainnet ++ [""] ++ instLinks InstallerStaging
   where
-    ciLinks = nub $ map (("* " <>) . ciResultUrl . snd) rs
-    instLinks net = (format (w%" installers:") net:[ fmt arch (ciResultDownloadUrl res)
-                                                   | (arch, res) <- rs, isNet net res ])
+    ciLinks = nub $ map (("* " <>) . ciResultUrl) rs
+    instLinks net = (format (w%" installers:") net:[ fmt res | res <- rs, isNet net res ])
     isNet net = (== Just net) . installerNetwork . ciResultLocalPath
-    fmt arch = format (s%" - "%s) (formatArch arch)
+    fmt res = format (s%" - "%s) (formatArch $ ciResultArch res) (ciResultDownloadUrl res)
 
 formatVersionInfo :: GlobalResults -> Text
 formatVersionInfo GlobalResults{..} = T.unlines
@@ -251,16 +267,14 @@ parseStatusContext status = parseAppveyor <|> parseBuildKite
     isAppveyor = context status == "continuous-integration/appveyor/branch"
     isBuildkite = "buildkite/" `T.isPrefixOf` context status
 
-findInstallersFromStatus :: BK.APIToken -> Maybe FilePath -> InstallerPredicate -> Status -> IO [(Arch, CIResult)]
-findInstallersFromStatus buildkiteToken destDir instP status =
+findInstallersFromStatus :: BK.APIToken -> Maybe FilePath -> Status -> IO (Either Text [CIResult])
+findInstallersFromStatus buildkiteToken destDir status =
   case parseStatusContext status of
     Just (StatusContextBuildkite _repo buildNum) ->
-      findInstallersBuildKite buildkiteToken destDir instP buildNum (targetUrl status)
+      findInstallersBuildKite buildkiteToken destDir buildNum (targetUrl status)
     Just (StatusContextAppveyor user project version) ->
-      findInstallersAppVeyor destDir instP (targetUrl status) user project version
-    Nothing -> do
-      putStrLn $ "unrecognized CI status: " <> T.unpack (context status)
-      pure []
+      findInstallersAppVeyor destDir (targetUrl status) user project version
+    Nothing -> pure $ Left $ "unrecognized CI status: " <> context status
 
 githubWikiRecord :: InstallersResults -> Text
 githubWikiRecord InstallersResults{..} = T.intercalate " | " cols <> "\n"
@@ -276,7 +290,7 @@ githubWikiRecord InstallersResults{..} = T.intercalate " | " cols <> "\n"
     githubLink rev project = githubLink' (rev globalResult) project
     githubLink' rev project = mdLink (T.take 6 rev) (format ("https://github.com/input-output-hk/"%s%"/commit/"%s) project rev)
 
-    ciLink arch = maybe "*missing*" ciLink' $ lookup arch ciResults
+    ciLink arch = maybe "*missing*" ciLink' $ find ((== arch) . ciResultArch) ciResults
     ciLink' CIResult{..} = mdLink (format d ciResultBuildNumber) ciResultUrl
 
     mdLink = format ("["%s%"]("%s%")")

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -23,6 +23,7 @@ import qualified Control.Foldl as Fold
 import Data.Char (isHexDigit)
 import Data.Bifunctor (first)
 import Data.Maybe (fromMaybe)
+import Data.List (find)
 
 import NixOps ( Options, NixopsConfig(..)
               , nixopsConfigurationKey, configurationKeys
@@ -278,7 +279,7 @@ instance Checkable UpdateProposalConfig2 where
         | otherwise = Nothing
         where
           GlobalResults{..} = globalResult
-          missingVersion arch = not . any ((== arch) . fst)
+          missingVersion arch = not . any ((== arch) . ciResultArch)
 
 instance Checkable UpdateProposalConfig3 where
   checkConfig (UpdateProposalConfig3 p h) = checkConfig p <|> checkConfig h
@@ -465,7 +466,7 @@ updateProposalSignInstallers :: CommandOptions -> Text -> Shell ()
 updateProposalSignInstallers opts@CommandOptions{..} userId = do
   params <- loadParams opts
   void $ doCheckConfig params
-  mapM_ signInstaller (map (ciResultLocalPath . snd) . ciResults . cfgInstallersResults $ params)
+  mapM_ signInstaller (map ciResultLocalPath . ciResults . cfgInstallersResults $ params)
   where
     signInstaller f = procs "gpg2" ["-u", userId, "--detach-sig", "--armor", "--sign", tt f] empty
 
@@ -526,9 +527,9 @@ chomp = fmap T.stripEnd . strict . limit 1
 
 -- | Slurp in previously created signatures.
 uploadSignatures :: Text -> InstallersResults -> Shell [(Arch, Maybe Text)]
-uploadSignatures bucket InstallersResults{..} = forM ciResults $ \(a, res) -> do
+uploadSignatures bucket InstallersResults{..} = forM ciResults $ \res -> do
   sig <- liftIO $ uploadResultSignature bucket res
-  pure (a, sig)
+  pure (ciResultArch res, sig)
 
 uploadResultSignature :: Text -> CIResult -> IO (Maybe Text)
 uploadResultSignature bucket res = liftIO $ maybeReadFile sigFile >>= \case
@@ -627,7 +628,7 @@ updateProposalGenerate opts@CommandOptions{..} = do
   echo "*** Carefully check the parameters yaml file."
 
 needResult :: MonadIO io => Arch -> InstallersResults -> (CIResult -> io a) -> io a
-needResult arch rs action = case lookup arch (ciResults rs) of
+needResult arch rs action = case Data.List.find ((== arch) . ciResultArch) (ciResults rs) of
   Just r -> action r
   Nothing -> die $ format ("The CI result for "%w%" is required but was not found.") arch
 

--- a/iohk/Utils.hs
+++ b/iohk/Utils.hs
@@ -20,7 +20,6 @@ import           Network.HTTP.Client.TLS   (newTlsManager)
 import           Network.HTTP.Types.Header (RequestHeaders)
 import           System.Exit               (ExitCode (ExitFailure, ExitSuccess))
 import qualified Data.Aeson                    as AE
-import qualified Data.Aeson.Types              as AE
 import qualified Data.Char                     as C
 import           Data.Text                        (Text)
 import           GHC.Generics              hiding (from, to)
@@ -32,8 +31,8 @@ import qualified Network.AWS.Data          as AWS
 fetchCachedUrl :: HasCallStack => T.Text -> FilePath -> FilePath -> IO ()
 fetchCachedUrl url name outPath = fetchCachedUrl' url name outPath Nothing
 
-fetchCachedUrlWithSHA1 :: HasCallStack => T.Text -> FilePath -> FilePath -> T.Text -> IO ()
-fetchCachedUrlWithSHA1 url name outPath sha1 = fetchCachedUrl' url name outPath (Just sha1)
+fetchCachedUrlWithSHA1 :: HasCallStack => T.Text -> T.Text -> FilePath -> FilePath -> IO ()
+fetchCachedUrlWithSHA1 sha1 url name outPath = fetchCachedUrl' url name outPath (Just sha1)
 
 fetchCachedUrl' :: HasCallStack => T.Text -> FilePath -> FilePath -> Maybe T.Text -> IO ()
 fetchCachedUrl' url name outPath sha1 = proc "nix-build" args mempty >>= handleExit


### PR DESCRIPTION
This recognises the `.bin` files on Buildkite as Linux installers.
It is no longer a fatal error if no installers are found for a certain CI system.

It doesn't include linux64 in the update proposal.
