### PR TITLE
[DEVOPS-923] only install nixops on the deployer

### DIFF
--- a/deployments/infrastructure-env-production.nix
+++ b/deployments/infrastructure-env-production.nix
@@ -26,6 +26,7 @@ in {
     imports = [
       ./../modules/datadog.nix
       ./../modules/papertrail.nix
+      ../modules/deployer.nix
     ];
 
     services.dd-agent.tags = ["env:production" "depl:${config.deployment.name}"];

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -2,9 +2,7 @@
 
 with (import ./../lib.nix);
 
-let
-  iohk-pkgs = import ../default.nix {};
-in {
+{
   imports = [
     ./ntp_fix.nix
     ./extra-statsd.nix
@@ -16,7 +14,7 @@ in {
 
   environment.systemPackages = with pkgs;
     # nixopsUnstable: wait for 1.5.1 release
-    [ git tmux vim sysstat iohk-pkgs.nixops lsof ncdu tree mosh tig
+    [ git tmux vim sysstat lsof ncdu tree mosh tig
       cabal2nix stack iptables graphviz tcpdump strace gdb binutils nix-repl ];
 
   services.openssh.passwordAuthentication = false;

--- a/modules/deployer.nix
+++ b/modules/deployer.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+let
+  iohk-pkgs = import ../default.nix {};
+in {
+  environment.systemPackages = [ iohk-pkgs.nixops ];
+}


### PR DESCRIPTION
for an unknown reason, this reduces the memory usage of mainnet massively