### PR TITLE
[DEVOPS-907] Fix cardano-service configuration

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "a32962830e8a99e3fbf9c29f586bc325a001af35",
-  "sha256": "14bgizxby5jcnjn7n0xpaff1gy524aakl76fbr1bpr404196blbq",
+  "rev": "f7b6661121f1eead48043d99b9081d5ab52ff519",
+  "sha256": "1ccr3qhrvsbyjgd6pvw38vcb2dasvz577jqcw93939jz22g21j6p",
   "fetchSubmodules": true
 }

--- a/iohk/NixOps.hs
+++ b/iohk/NixOps.hs
@@ -50,7 +50,7 @@ module NixOps (
   , parallelIO
   , nixopsConfigurationKey
   , configurationKeys
-  , getCardanoSLSource
+  , getCardanoSLConfig
 
   -- * Types
   , Arg(..)
@@ -799,9 +799,9 @@ build o _c depl = do
 
 
 -- | Use nix to grab the sources of cardano-sl.
-getCardanoSLSource :: Options -> IO Path.FilePath
-getCardanoSLSource o = parent . fromText <$> incmdStrip o "nix-instantiate" args
-  where args = [ "--read-write-mode", "--eval", "-A", "cardano-sl.src", "default.nix" ]
+getCardanoSLConfig :: Options -> IO Path.FilePath
+getCardanoSLConfig o = parent . fromText <$> incmdStrip o "nix-instantiate" args
+  where args = [ "--read-write-mode", "--eval", "-A", "cardano-sl-config", "default.nix" ]
 
 
 -- * State management

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -27,7 +27,7 @@ import Data.List (find)
 
 import NixOps ( Options, NixopsConfig(..)
               , nixopsConfigurationKey, configurationKeys
-              , getCardanoSLSource )
+              , getCardanoSLConfig )
 import Types ( NixopsDepl(..), Environment(..), Arch(..) )
 import UpdateLogic ( InstallersResults(..), CIResult(..)
                    , realFindInstallers, githubWikiRecord
@@ -126,7 +126,7 @@ updateProposal o cfg UpdateProposalCommand{..} = do
   configKey <- maybe (fail "configurationKey not found") pure (nixopsConfigurationKey cfg)
   top <- pwd
   uid <- makeUpdateId (cName cfg) updateProposalDate
-  cslPath <- getCardanoSLSource o
+  cslPath <- getCardanoSLConfig o
   let opts = commandOptions (workPath top uid) cslPath configKey (cUpdateBucket cfg)
   sh $ case updateProposalStep of
     UpdateProposalInit initial -> updateProposalInit top uid (first (UpdateID (cName cfg)) initial)

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -334,10 +334,10 @@ runNew _ _ _ = error "impossible"
 -- | Use 'cardano-keygen' to create keys for a develoment cluster.
 generateStakeKeys :: Options -> ConfigurationKey -> Turtle.FilePath -> IO ()
 generateStakeKeys o configurationKey outdir = do
-  cardanoSrc <- getCardanoSLSource o
+  cardanoConfig <- getCardanoSLConfig o
   cmd o "cardano-keygen"
     [ "--system-start", "0"
-    , "--configuration-file", format (fp%"/lib/configuration.yaml") cardanoSrc
+    , "--configuration-file", format (fp%"/lib/configuration.yaml") cardanoConfig
     , "--configuration-key", fromConfigurationKey configurationKey
     , "generate-keys-by-spec"
     , "--genesis-out-dir", T.pack $ Path.encodeString outdir

--- a/modules/cardano-service.nix
+++ b/modules/cardano-service.nix
@@ -6,7 +6,9 @@ let
   cfg = config.services.cardano-node;
   name = "cardano-node";
   stateDir = "/var/lib/cardano-node";
-  cardano = (import ./../default.nix { enableProfiling = cfg.enableProfiling; }).cardano-sl-node-static;
+  iohkPkgs = import ./../default.nix { enableProfiling = cfg.enableProfiling; };
+  cardano = iohkPkgs.cardano-sl-node-static;
+  cardano-config = iohkPkgs.cardano-sl-config;
   distributionParam = "(${toString cfg.genesisN},${toString cfg.totalMoneyAmount})";
   rnpDistributionParam = "(${toString cfg.genesisN},50000,${toString cfg.totalMoneyAmount},0.99)";
   smartGenIP = builtins.getEnv "SMART_GEN_IP";
@@ -40,11 +42,11 @@ let
       "--keyfile ${stateDir}/key${toString cfg.nodeIndex}.sk")
     (optionalString (cfg.productionMode && globals.systemStart != 0) "--system-start ${toString globals.systemStart}")
     (optionalString cfg.supporter "--supporter")
-    "--log-config ${cardano.src + "/../log-configs/cluster.yaml"}"
+    "--log-config ${cardano-config}/log-configs/cluster.yaml"
     "--logs-prefix /var/lib/cardano-node"
     "--db-path ${stateDir}/node-db"
     (optionalString (!cfg.enableP2P) "--kademlia-explicit-initial --disable-propagation ${smartGenPeer}")
-    "--configuration-file ${cardano.src + "/../lib/"}/configuration.yaml"
+    "--configuration-file ${cardano-config}/lib/configuration.yaml"
     "--configuration-key ${config.deployment.arguments.configurationKey}"
     "--topology ${cfg.topologyYaml}"
     "--node-id ${params.name}"


### PR DESCRIPTION
Using `cardano-sl.src` got broken after adding filtering of the sources.
See corresponding fix in input-output-hk/cardano-sl#3090.
