### PR TITLE
[DEVOPS-923] reduce mainnet eval memory usage by another 3.5gig

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,19 @@ let
     in (import "${nixopsUnstable}/release.nix" {
          nixpkgs = localLib.fetchNixPkgs;
         }).build.${system};
+  nix-src = pkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nix";
+    rev = "0395b9b94af56bb814810a32d680c606614b29e0";
+    sha256 = "1np655i8gxx8pyc7469q5fz85vqrlpxs4z9jcbc2h8v5mrlzx9hk";
+  };
+  nix = pkgs.nix.overrideAttrs (drv: {
+    src = nix-src;
+    nativeBuildInputs = drv.nativeBuildInputs ++ [ pkgs.bison pkgs.flex pkgs.autoreconfHook ];
+    name = "nix-memoise";
+    configureFlags = drv.configureFlags ++ [ "--disable-doc-gen" ];
+    outputs = [ "out" "dev" ];
+  });
   iohk-ops-extra-runtime-deps = with pkgs; [
     gitFull nix-prefetch-scripts compiler.yaml
     wget
@@ -68,5 +81,5 @@ let
   '';
 
 in {
-  inherit nixops iohk-ops iohk-ops-integration-test;
+  inherit nixops iohk-ops iohk-ops-integration-test nix;
 } // cardano-sl-pkgs

--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -17,6 +17,6 @@ let
   cardano-sl-src = builtins.fromJSON (builtins.readFile ./../cardano-sl-src.json);
   cardanoSrc = pkgs.fetchgit cardano-sl-src;
 in rec {
-  inherit (jobs) iohk-ops iohk-ops-integration-test nixops;
+  inherit (jobs) iohk-ops iohk-ops-integration-test nixops nix;
   tests          = import ./../tests     { inherit pkgs; supportedSystems = [ "x86_64-linux" ]; };
 } // (import "${cardanoSrc}/release.nix" { cardano = { outPath = cardanoSrc; rev = cardano-sl-src.rev; }; })

--- a/modules/cardano-service.nix
+++ b/modules/cardano-service.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.cardano-node;
   name = "cardano-node";
   stateDir = "/var/lib/cardano-node";
-  iohkPkgs = import ./../default.nix { enableProfiling = cfg.enableProfiling; };
+  iohkPkgs = builtins.memoise (import ./../default.nix) { enableProfiling = cfg.enableProfiling; };
   cardano = iohkPkgs.cardano-sl-node-static;
   cardano-config = iohkPkgs.cardano-sl-config;
   distributionParam = "(${toString cfg.genesisN},${toString cfg.totalMoneyAmount})";

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -71,8 +71,9 @@ COMMON_OPTIONS=( --topology topology-min.yaml )
 CARDANO_COMPONENTS=( Nodes ${WITH_EXPLORER:+Explorer} ${WITH_REPORT_SERVER:+ReportServer} )
 
 nix-build default.nix -A cardano-sl-tools -o cardano-sl-tools
+nix-build default.nix -A nix -o nix
 
-PATH=$PATH:./cardano-sl-tools/bin/
+PATH=./nix/bin/:$PATH:./cardano-sl-tools/bin/
 export PATH
 
 if test -n "${WITH_STAGING}"; then

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@ let
   iohkpkgs = import ./default.nix {};
   iohk-ops = iohkpkgs.iohk-ops;
   justIo = pkgs.runCommand "shell" {
-    buildInputs = with pkgs; [ iohk-ops terraform_0_11 nixops ];
+    buildInputs = with pkgs; [ iohk-ops terraform_0_11 nixops iohkpkgs.nix];
     passthru = {
       inherit ioSelfBuild withAuxx;
     };
@@ -26,6 +26,7 @@ let
       iohk-ops
       iohkpkgs.cardano-sl-auxx
       iohkpkgs.cardano-sl-tools
+      iohkpkgs.nix
     ];
   } "echo use nix-shell";
 in justIo


### PR DESCRIPTION
https://gist.github.com/cleverca22/c99163e94b26d896f511d3540ce7303d

this switches the `shell.nix` env over to using the https://github.com/nixos/nix/tree/memoise branch of nix, and then uses it to deduplicate the mainnet deployment some
this first change shaves 3.5gig off the memory usage, bringing it from 34.8gig to 31.3gig