### PR TITLE
update the edgenode deployment to work with the new cardano

### DIFF
--- a/deployments/edgenodesv2.nix
+++ b/deployments/edgenodesv2.nix
@@ -1,6 +1,7 @@
 { accessKeyId, nodes ? 1 , walletsPerNode ? 1
 , region ? "eu-central-1"
-, topologyFile, systemStart }:
+, topologyFile, systemStart
+, configKey ? "bench" }:
 
 with import ../lib.nix;
 let
@@ -8,7 +9,9 @@ let
     name = "edgenode-${toString index}";
     value = {
       imports = [ ../modules/cardano-benchmark.nix ];
-      services.cardano-benchmark.index = index;
+      services.cardano-benchmark = {
+        inherit configKey index;
+      };
     };
   };
 in {

--- a/modules/cardano-benchmark.nix
+++ b/modules/cardano-benchmark.nix
@@ -11,7 +11,7 @@ let
     walletListen = "127.0.0.1:${toString (8090 + index)}";
     ekgListen = "127.0.0.1:${toString (8000 + index)}";
     environment = "override";
-    confKey = "bench";
+    confKey = cfg.configKey;
     extraParams = "--system-start ${toString cfg.systemStart}";
   };
   mkService = index: {
@@ -20,7 +20,7 @@ let
       serviceConfig = {
         User = "cardano-node-${toString index}";
         WorkingDirectory = "/home/cardano-node-${toString index}";
-        ExecStart = iohkpkgs.connectScripts.mainnetWallet.override (params index);
+        ExecStart = iohkpkgs.connectScripts.mainnet.wallet.override (params index);
       };
     };
   };
@@ -42,6 +42,9 @@ in {
         type = types.int;
       };
       topologyFile = mkOption {
+        type = types.str;
+      };
+      configKey = mkOption {
         type = types.str;
       };
     };


### PR DESCRIPTION
```
nixops create -d edgenodes deployments/edgenodesv2.nix
nixops set-args -d edgenodes --argstr accessKeyId staging-key --arg nodes 1 --arg walletsPerNode 2 --arg topologyFile ./topology-stress-test.yaml --arg systemStart 1506450213 --argstr configKey mainnet_dryrun_full
```
and a topology file:
```
wallet:
  fallbacks: 7
  valency: 1
  relays:
  - - ip: 1.2.3.4
```
that is enough to spawn 2 wallets on 1 node in aws