### PR TITLE
ci | bench:  don't test the bench env by default:  too slow to gen 50k keys

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -19,7 +19,7 @@ WITH_INFRA_PRODUCTION=${9:-true}
 shift || true
 WITH_INFRA_STAGING=${9:-true}
 shift || true
-WITH_BENCHMARK=${9:-true}
+WITH_BENCHMARK=${9:-}
 
 homestate="$(mktemp -d -t iohk-ops.XXXXXXXXXXXX)"
 export HOME="${homestate}"


### PR DESCRIPTION
@365andreas, that 50k key generation in the benchmark test is slow -- what should we do about it?

This disables bench environment testing by default.