### PR TITLE
Change defaultIOPSBranch from 'develop' to 'master'

### DIFF
--- a/iohk/Constants.hs
+++ b/iohk/Constants.hs
@@ -21,7 +21,7 @@ defaultTarget        = AWS
 defaultNode          = NodeName "c-a-1"
 defaultNodePort      = PortNo 3000
 
-defaultIOPSBranch    = Branch "develop"
+defaultIOPSBranch    = Branch "master"
 
 defaultHold          = 1200 :: Seconds -- 20 minutes
 

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -135,7 +135,7 @@ centralCommandParser =
                                 Clone
                                 <$> (NixopsDepl <$> argText "NAME"  "Nixops deployment name")
                                 <*> (fromMaybe defaultIOPSBranch
-                                     <$> (optional (parserBranch "'iohk-ops' branch to checkout.  Defaults to 'develop'"))))
+                                     <$> (optional (parserBranch "'iohk-ops' branch to checkout.  Defaults to 'master'"))))
     , ("new",                   "Produce (or update) a checkout of BRANCH with a cluster config YAML file (whose default name depends on the ENVIRONMENT), primed for future operations.",
                                 New
                                 <$> optional (optPath "config"        'c' "Override the default, environment-dependent config filename")


### PR DESCRIPTION
It seems that 'develop' was abandoned ~120 commits ago, but the default
was not updated, which caused a confusing error due to config path
inconsistencies. 'master' seems to be the main branch, so I'm updating
accordingly.