### PR TITLE
[DEVOPS-788] [DEVOPS-868] Update proposal Linux support and signing fix

### DIFF
--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -42,7 +42,7 @@ import Types ( NixopsDepl(..), Environment(..), Arch(..)
              , archMapToList, archMapFromList, lookupArch
              , idArchMap, archMapEach)
 import UpdateLogic ( InstallersResults(..), CIResult(..)
-                   , realFindInstallers, githubWikiRecord
+                   , getInstallersResults, githubWikiRecord
                    , runAWS', uploadHashedInstaller, updateVersionJson
                    , uploadSignature )
 import RunCardano
@@ -441,7 +441,7 @@ updateProposalFindInstallers opts env = do
   echo "*** Finding installers"
   let rev = unGitRevision . cfgDaedalusRevision $ params
       destDir = Just (installersDir opts)
-  res <- liftIO $ realFindInstallers (configurationKeys env) (installerForEnv env) rev destDir
+  res <- liftIO $ getInstallersResults (configurationKeys env) (installerForEnv env) rev destDir
 
   echo "*** Hashing installers with sha256sum"
   sha256 <- getHashes sha256sum res

--- a/iohk/common/Arch.hs
+++ b/iohk/common/Arch.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
+
+module Arch
+  ( Arch(..)
+  , ArchMap
+  , ApplicationVersionKey
+  , formatArch
+  , archMap
+  , mkArchMap
+  , archMapToList
+  , archMapFromList
+  , lookupArch
+  , idArchMap
+  , archMapEach
+  ) where
+
+import qualified Data.Aeson            as AE
+import           Data.Aeson
+import           Data.Text              (Text)
+import           GHC.Generics
+
+-- * Arch
+data Arch = Linux64 | Mac64 | Win64 deriving (Show, Read, Eq, Generic)
+
+instance FromJSON Arch
+instance ToJSON Arch
+
+type ApplicationVersionKey = Arch -> Text
+
+formatArch :: Arch -> Text
+formatArch Linux64 = "Linux"
+formatArch Mac64 = "macOS"
+formatArch Win64 = "Windows"
+
+-- | A map of values indexed by Arch.
+-- Maybe "type ArchMap a = Arch -> a" would be better but this works.
+data ArchMap a = ArchMap { linux64 :: !a, mac64 :: !a, win64 :: !a }
+  deriving (Show, Read, Eq, Generic, Functor, Foldable, Traversable)
+
+instance Applicative ArchMap where
+  pure a = ArchMap a a a
+  ArchMap f g h <*> ArchMap l m w = ArchMap (f l) (g m) (h w)
+
+-- | Construct an arch map using fixed values.
+mkArchMap :: a -- ^ Linux value
+          -> a -- ^ macOS value
+          -> a -- ^ Windows value
+          -> ArchMap a
+mkArchMap l m w = ArchMap l m w
+
+-- | Construct an arch map with a lookup function.
+archMap :: (Arch -> a) -> ArchMap a
+archMap get = ArchMap (get Linux64) (get Mac64) (get Win64)
+
+-- | Get the value for a given arch.
+lookupArch :: Arch -> ArchMap a -> a
+lookupArch Linux64 (ArchMap a _ _) = a
+lookupArch Mac64   (ArchMap _ a _) = a
+lookupArch Win64   (ArchMap _ _ a) = a
+
+-- | Returns the map as a list of (Arch, value) pairs.
+archMapToList :: ArchMap a -> [(Arch, a)]
+archMapToList (ArchMap l m w) = [(Linux64, l), (Mac64, m), (Win64, w)]
+
+idArchMap :: ArchMap Arch
+idArchMap = ArchMap Linux64 Mac64 Win64
+
+-- | Returns the map as a list of (Arch, value) pairs, where not all
+-- arches are present.
+archMapToList' :: ArchMap (Maybe a) -> [(Arch, a)]
+archMapToList' am = [(a, v) | (a, Just v) <- archMapToList am]
+
+-- | Construct an arch map from a list of pairs.
+archMapFromList :: [(Arch, a)] -> ArchMap (Maybe a)
+archMapFromList = build (pure Nothing)
+  where
+    build am [] = am
+    build am (e:es) = build (add e am) es
+    add (Linux64, l) (ArchMap _ m w) = ArchMap (Just l) m w
+    add (Mac64, m)   (ArchMap l _ w) = ArchMap l (Just m) w
+    add (Win64, w)   (ArchMap l m _) = ArchMap l m (Just w)
+
+instance FromJSON a => FromJSON (ArchMap a) where
+  parseJSON = AE.withObject "ArchMap" $ \o ->
+    mkArchMap <$> o .: "linux" <*> o .: "darwin" <*> o .: "windows"
+
+instance ToJSON a => ToJSON (ArchMap a) where
+  toJSON am = AE.object [ "linux" .= lookupArch Linux64 am
+                        , "darwin" .= lookupArch Mac64 am
+                        , "windows" .= lookupArch Win64 am ]
+
+-- | Run an action for each arch. The difference between this and
+-- 'fmap' is that the action receives an arch parameter.
+archMapEach :: Applicative f => (Arch -> a -> f b) -> ArchMap a -> f (ArchMap b)
+archMapEach f (ArchMap l m w) = ArchMap <$> f Linux64 l <*> f Mac64 m <*> f Win64 w

--- a/iohk/common/NixOps.hs
+++ b/iohk/common/NixOps.hs
@@ -896,7 +896,7 @@ configurationKeys env _ = error $ "Application versions not used in '" <> show e
 
 findInstallers :: NixopsConfig -> T.Text -> Maybe FilePath -> IO ()
 findInstallers c daedalusRev destDir = do
-  installers <- realFindInstallers (configurationKeys $ cEnvironment c) (const True) daedalusRev destDir
+  installers <- getInstallersResults (configurationKeys $ cEnvironment c) (const True) daedalusRev destDir
   printInstallersResults installers
   case destDir of
     Just dir -> void $ proc "ls" [ "-ltrha", tt dir ] mempty

--- a/iohk/common/Types.hs
+++ b/iohk/common/Types.hs
@@ -5,11 +5,13 @@
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE DeriveFunctor              #-}
 {-# OPTIONS_GHC -Wall -Wno-name-shadowing -Wno-missing-signatures -Wno-type-defaults #-}
 
 module Types where
 
 import qualified Data.Aeson            as AE
+import           Data.Aeson            ((.=), (.:))
 import qualified Data.ByteString.Char8 as BS.C8
 import           Data.Csv              (FromField (..))
 import qualified GHC.Generics          as G
@@ -46,17 +48,71 @@ newtype FQDN         = FQDN         { fromFQDN         :: Text   } deriving (Fro
 newtype IP           = IP           { getIP            :: Text   } deriving (Show, Generic, FromField)
 newtype PortNo       = PortNo       { fromPortNo       :: Int    } deriving (FromJSON, Generic, Show, ToJSON)
 newtype Username     = Username     { fromUsername     :: Text   } deriving (FromJSON, Generic, Show, IsString, ToJSON)
-data Arch = Linux64 | Mac64 | Win64 deriving (Show, Read, Eq, Generic)
 newtype ApplicationVersion = ApplicationVersion { getApplicationVersion :: Text } deriving (FromJSON, IsString, Show, Eq, Generic, ToJSON)
-type ApplicationVersionKey = Arch -> Text
+
+-- * Arch
+data Arch = Linux64 | Mac64 | Win64 deriving (Show, Read, Eq, Generic)
 
 instance FromJSON Arch
 instance ToJSON Arch
+
+type ApplicationVersionKey = Arch -> Text
 
 formatArch :: Arch -> Text
 formatArch Linux64 = "Linux"
 formatArch Mac64 = "macOS"
 formatArch Win64 = "Windows"
+
+-- | A map of values indexed by Arch.
+-- Maybe "type ArchMap a = Arch -> a" would be better but this works.
+data ArchMap a = ArchMap { linux64 :: !a, mac64 :: !a, win64 :: !a }
+  deriving (Show, Read, Eq, Generic, Functor)
+
+-- | Construct an arch map using fixed values.
+mkArchMap :: a -- ^ Linux value
+          -> a -- ^ macOS value
+          -> a -- ^ Windows value
+          -> ArchMap a
+mkArchMap l m w = ArchMap l m w
+
+-- | Construct an arch map with a lookup function.
+archMap :: (Arch -> a) -> ArchMap a
+archMap get = ArchMap (get Linux64) (get Mac64) (get Win64)
+
+-- | Get the value for a given arch.
+lookupArch :: Arch -> ArchMap a -> a
+lookupArch Linux64 (ArchMap a _ _) = a
+lookupArch Mac64   (ArchMap _ a _) = a
+lookupArch Win64   (ArchMap _ _ a) = a
+
+-- | Returns the map as a list of (Arch, value) pairs.
+archMapToList :: ArchMap a -> [(Arch, a)]
+archMapToList (ArchMap l m w) = [(Linux64, l), (Mac64, m), (Win64, w)]
+
+-- | Returns the map as a list of (Arch, value) pairs, where not all
+-- arches are present.
+archMapToList' :: ArchMap (Maybe a) -> [(Arch, a)]
+archMapToList' am = [(a, v) | (a, Just v) <- archMapToList am]
+
+-- | Construct an arch map from a list of pairs.
+archMapFromList :: [(Arch, a)] -> ArchMap (Maybe a)
+archMapFromList = build (ArchMap Nothing Nothing Nothing)
+  where
+    build am [] = am
+    build am (e:es) = build (add e am) es
+    add (Linux64, l) (ArchMap _ m w) = ArchMap (Just l) m w
+    add (Mac64, m)   (ArchMap l _ w) = ArchMap l (Just m) w
+    add (Win64, w)   (ArchMap l m _) = ArchMap l m (Just w)
+
+instance FromJSON a => FromJSON (ArchMap a) where
+  parseJSON = AE.withObject "ArchMap" $ \o ->
+    mkArchMap <$> o .: "linux" <*> o .: "darwin" <*> o .: "windows"
+
+instance ToJSON a => ToJSON (ArchMap a) where
+  toJSON am = AE.object [ "linux" .= lookupArch Linux64 am
+                        , "darwin" .= lookupArch Mac64 am
+                        , "windows" .= lookupArch Win64 am ]
+
 
 -- * Flags
 --

--- a/iohk/common/Types.hs
+++ b/iohk/common/Types.hs
@@ -5,13 +5,15 @@
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE DeriveFunctor              #-}
 {-# OPTIONS_GHC -Wall -Wno-name-shadowing -Wno-missing-signatures -Wno-type-defaults #-}
 
-module Types where
+module Types
+  ( module Types
+  , module Arch
+  ) where
 
+import           Prelude               hiding (FilePath)
 import qualified Data.Aeson            as AE
-import           Data.Aeson            ((.=), (.:))
 import qualified Data.ByteString.Char8 as BS.C8
 import           Data.Csv              (FromField (..))
 import qualified GHC.Generics          as G
@@ -21,9 +23,9 @@ import           Data.Text
 import           Data.Word             (Word16)
 import           Data.Yaml             (FromJSON (..), ToJSON (..))
 import           GHC.Generics          hiding (from, to)
-import           Prelude               hiding (FilePath)
 import qualified Turtle                        as Turtle
 
+import Arch
 
 -- * Elementary types
 --
@@ -49,74 +51,6 @@ newtype IP           = IP           { getIP            :: Text   } deriving (Sho
 newtype PortNo       = PortNo       { fromPortNo       :: Int    } deriving (FromJSON, Generic, Show, ToJSON)
 newtype Username     = Username     { fromUsername     :: Text   } deriving (FromJSON, Generic, Show, IsString, ToJSON)
 newtype ApplicationVersion = ApplicationVersion { getApplicationVersion :: Text } deriving (FromJSON, IsString, Show, Eq, Generic, ToJSON)
-
--- * Arch
-data Arch = Linux64 | Mac64 | Win64 deriving (Show, Read, Eq, Generic)
-
-instance FromJSON Arch
-instance ToJSON Arch
-
-type ApplicationVersionKey = Arch -> Text
-
-formatArch :: Arch -> Text
-formatArch Linux64 = "Linux"
-formatArch Mac64 = "macOS"
-formatArch Win64 = "Windows"
-
--- | A map of values indexed by Arch.
--- Maybe "type ArchMap a = Arch -> a" would be better but this works.
-data ArchMap a = ArchMap { linux64 :: !a, mac64 :: !a, win64 :: !a }
-  deriving (Show, Read, Eq, Generic, Functor)
-
--- | Construct an arch map using fixed values.
-mkArchMap :: a -- ^ Linux value
-          -> a -- ^ macOS value
-          -> a -- ^ Windows value
-          -> ArchMap a
-mkArchMap l m w = ArchMap l m w
-
--- | Construct an arch map using the same value for each arch.
-straightArchMap :: a -> ArchMap a
-straightArchMap a = ArchMap a a a
-
--- | Construct an arch map with a lookup function.
-archMap :: (Arch -> a) -> ArchMap a
-archMap get = ArchMap (get Linux64) (get Mac64) (get Win64)
-
--- | Get the value for a given arch.
-lookupArch :: Arch -> ArchMap a -> a
-lookupArch Linux64 (ArchMap a _ _) = a
-lookupArch Mac64   (ArchMap _ a _) = a
-lookupArch Win64   (ArchMap _ _ a) = a
-
--- | Returns the map as a list of (Arch, value) pairs.
-archMapToList :: ArchMap a -> [(Arch, a)]
-archMapToList (ArchMap l m w) = [(Linux64, l), (Mac64, m), (Win64, w)]
-
--- | Returns the map as a list of (Arch, value) pairs, where not all
--- arches are present.
-archMapToList' :: ArchMap (Maybe a) -> [(Arch, a)]
-archMapToList' am = [(a, v) | (a, Just v) <- archMapToList am]
-
--- | Construct an arch map from a list of pairs.
-archMapFromList :: [(Arch, a)] -> ArchMap (Maybe a)
-archMapFromList = build (straightArchMap Nothing)
-  where
-    build am [] = am
-    build am (e:es) = build (add e am) es
-    add (Linux64, l) (ArchMap _ m w) = ArchMap (Just l) m w
-    add (Mac64, m)   (ArchMap l _ w) = ArchMap l (Just m) w
-    add (Win64, w)   (ArchMap l m _) = ArchMap l m (Just w)
-
-instance FromJSON a => FromJSON (ArchMap a) where
-  parseJSON = AE.withObject "ArchMap" $ \o ->
-    mkArchMap <$> o .: "linux" <*> o .: "darwin" <*> o .: "windows"
-
-instance ToJSON a => ToJSON (ArchMap a) where
-  toJSON am = AE.object [ "linux" .= lookupArch Linux64 am
-                        , "darwin" .= lookupArch Mac64 am
-                        , "windows" .= lookupArch Win64 am ]
-
 
 -- * Flags
 --

--- a/iohk/common/Types.hs
+++ b/iohk/common/Types.hs
@@ -75,6 +75,10 @@ mkArchMap :: a -- ^ Linux value
           -> ArchMap a
 mkArchMap l m w = ArchMap l m w
 
+-- | Construct an arch map using the same value for each arch.
+straightArchMap :: a -> ArchMap a
+straightArchMap a = ArchMap a a a
+
 -- | Construct an arch map with a lookup function.
 archMap :: (Arch -> a) -> ArchMap a
 archMap get = ArchMap (get Linux64) (get Mac64) (get Win64)
@@ -96,7 +100,7 @@ archMapToList' am = [(a, v) | (a, Just v) <- archMapToList am]
 
 -- | Construct an arch map from a list of pairs.
 archMapFromList :: [(Arch, a)] -> ArchMap (Maybe a)
-archMapFromList = build (ArchMap Nothing Nothing Nothing)
+archMapFromList = build (straightArchMap Nothing)
   where
     build am [] = am
     build am (e:es) = build (add e am) es

--- a/iohk/common/UpdateLogic.hs
+++ b/iohk/common/UpdateLogic.hs
@@ -16,6 +16,7 @@ module UpdateLogic
   , updateVersionJson
   , githubWikiRecord
   , printInstallersResults
+  , CISystem(..)
   , InstallersResults(..)
   , GlobalResults(..)
   , parseStatusContext

--- a/iohk/common/Utils.hs
+++ b/iohk/common/Utils.hs
@@ -28,8 +28,6 @@ import           Network.AWS               (Region)
 import           Network.AWS.S3            (BucketName(..), ObjectKey(..))
 import qualified Network.AWS.Data          as AWS
 
-import           Types                     (Environment(..))
-
 fetchCachedUrl :: HasCallStack => T.Text -> FilePath -> FilePath -> IO ()
 fetchCachedUrl url name outPath = fetchCachedUrl' url name outPath Nothing
 

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -86,23 +86,35 @@ executable iohk-ops
                      , turtle
                      , unordered-containers
                      , yaml
+
 test-suite iohk-ops-test
   main-is:          Spec.hs
   default-language: Haskell2010
+  default-extensions: OverloadedStrings, RecordWildCards
+
   type:             exitcode-stdio-1.0
   other-modules:    AppveyorSpec
                   , Buildkite.Pipeline
                   , BuildkiteSpec
                   , UpdateLogicSpec
+                  , UpdateProposal
+                  , UpdateProposalSpec
   build-depends:    base
+                  , iohk-ops
                   , aeson
                   , bytestring
+                  , foldl
                   , hspec
-                  , iohk-ops
+                  , optparse-applicative
+                  , process
+                  , system-filepath
                   , text
+                  , time
+                  , turtle
                   , unordered-containers
                   , yaml
   hs-source-dirs:   test .
+
 executable iohk-ops-integration-test
   main-is:          IntegrationTest.hs
   default-language: Haskell2010

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -17,7 +17,9 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      common
   default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
   exposed-modules:     Appveyor
+                     , Arch
                      , Buildkite.API
                      , Constants
                      , Github
@@ -68,7 +70,7 @@ library
 executable iohk-ops
   main-is:             iohk-ops.hs
   default-language:    Haskell2010
-  other-extensions:    DeriveGeneric, GeneralizedNewtypeDeriving, OverloadedStrings, RecordWildCards, TupleSections, ViewPatterns
+  default-extensions:  OverloadedStrings
   other-modules:       UpdateProposal
 
   build-depends:       aeson
@@ -111,6 +113,7 @@ test-suite iohk-ops-test
                   , system-filepath
                   , text
                   , time
+                  , mtl
                   , turtle
                   , unordered-containers
                   , yaml

--- a/iohk/iohk-ops.cabal
+++ b/iohk/iohk-ops.cabal
@@ -80,6 +80,7 @@ executable iohk-ops
                      , iohk-ops
                      , optional-args
                      , optparse-applicative
+                     , process
                      , system-filepath
                      , text
                      , time

--- a/iohk/test/UpdateProposalSpec.hs
+++ b/iohk/test/UpdateProposalSpec.hs
@@ -15,9 +15,14 @@ spec :: Spec
 spec = do
   describe "Update proposal command" $ do
     it "Generates the correct command" $ do
-      proposeUpdateCmd testCommandOptions testConfig `shouldBe`
+      proposeUpdateCmd testCommandOptions testConfig allSystems `shouldBe`
         ("propose-update 99 vote-all:true 1.2.3 ~software~csl-daedalus:42 " <>
-         "(upd-bin \"linux64\" /workdir/installers/hash-linux) " <>
+         "(upd-bin \"linux\" /workdir/installers/hash-linux) " <>
+         "(upd-bin \"macos64\" /workdir/installers/hash-macos) " <>
+         "(upd-bin \"win64\" /workdir/installers/hash-win)")
+    it "Skips linux update if --with-linux option is disabled" $ do
+      proposeUpdateCmd testCommandOptions testConfig notLinux `shouldBe`
+        ("propose-update 99 vote-all:true 1.2.3 ~software~csl-daedalus:42 " <>
          "(upd-bin \"macos64\" /workdir/installers/hash-macos) " <>
          "(upd-bin \"win64\" /workdir/installers/hash-win)")
 
@@ -59,3 +64,9 @@ testInstallersResults = InstallersResults ci gr
                        , grCardanoVersion = "cardano-version"
                        , grDaedalusVersion = "daedalus-version"
                        }
+
+allSystems :: ArchMap Bool
+allSystems = straightArchMap True
+
+notLinux :: ArchMap Bool
+notLinux = mkArchMap False True True

--- a/iohk/test/UpdateProposalSpec.hs
+++ b/iohk/test/UpdateProposalSpec.hs
@@ -1,0 +1,61 @@
+module UpdateProposalSpec (spec) where
+
+import Test.Hspec hiding (context)
+
+import Data.Semigroup ((<>))
+import UpdateProposal
+import UpdateLogic
+import RunCardano (CommandOptions, commandOptions)
+import Types
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Update proposal command" $ do
+    it "Generates the correct command" $ do
+      proposeUpdateCmd testCommandOptions testConfig `shouldBe`
+        ("propose-update 99 vote-all:true 1.2.3 ~software~csl-daedalus:42 " <>
+         "(upd-bin \"linux64\" /workdir/installers/hash-linux) " <>
+         "(upd-bin \"macos64\" /workdir/installers/hash-macos) " <>
+         "(upd-bin \"win64\" /workdir/installers/hash-win)")
+
+testCommandOptions :: CommandOptions
+testCommandOptions = commandOptions "/workdir" "/cardano-source" "key_spec" "spec-s3"
+
+testConfig :: UpdateProposalConfig4
+testConfig = UpdateProposalConfig4
+  { cfgUpdateProposal3 = UpdateProposalConfig3
+    { cfgUpdateProposal2 = UpdateProposalConfig2
+      { cfgUpdateProposal1 = UpdateProposalConfig1
+        { cfgDaedalusRevision = undefined
+        , cfgLastKnownBlockVersion = "1.2.3"
+        , cfgVoterIndex = 99
+        }
+      , cfgInstallersResults = testInstallersResults
+      , cfgInstallerHashes = ArchMap "hash-linux" "hash-macos" "hash-win"
+      , cfgInstallerSHA256 = ArchMap "sha-linux" "sha-macos" "sha-win"
+      }
+    }
+  , cfgUpdateProposalAddrs = "addrs"
+  }
+
+testInstallersResults :: InstallersResults
+testInstallersResults = InstallersResults ci gr
+  where
+    ci = [ciResult Linux64, ciResult Mac64, ciResult Win64]
+    ciResult arch = CIResult { ciResultSystem = Buildkite
+                             , ciResultLocalPath = "spec-path"
+                             , ciResultUrl = "spec-url"
+                             , ciResultDownloadUrl = "spec-download-url"
+                             , ciResultBuildNumber = 666
+                             , ciResultArch = arch
+                             , ciResultSHA1Sum = Nothing
+                             }
+    gr = GlobalResults { grCardanoCommit = "cardano-rev"
+                       , grDaedalusCommit = "daedalus-rev"
+                       , grApplicationVersion = 42
+                       , grCardanoVersion = "cardano-version"
+                       , grDaedalusVersion = "daedalus-version"
+                       }


### PR DESCRIPTION
* [DEVOPS-788](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-788)
   - Adds support for proposing linux installers with `io update-proposal submit`.
   - Add a basic test case for checking the `cardano-auxx propose-update` command line.
* [DEVOPS-868](https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-868)
   - Pass tty to `gpg2` subprocess so that password entry works.
   - Make `io update-proposal find-installers -u user-id` optional so that the default signing key from the keyring can be used.
   - Move sha256 and blake2b hashing of installers earlier to the `find-installers` step.
