### PR TITLE
[DEVOPS-868] Update proposal automation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ image/
 logs/
 logs-analyze/
 /nixops
+/update-proposals/
 
 static/*.secret
 static/github_token

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -69,7 +69,6 @@ data UpdateProposalStep
     }
   | UpdateProposalUploadS3
   | UpdateProposalSetVersionJSON
-  | UpdateProposalGenerate
   | UpdateProposalSubmit
     { updateProposalRelayIP           :: Text
     , updateProposalDryRun            :: Bool
@@ -94,12 +93,9 @@ parseUpdateProposalCommand = subparser $
   <> ( command "set-version-json"
        (info ((UpdateProposalCommand <$> date <*> pure UpdateProposalSetVersionJSON) <**> helper)
          (progDesc "Update the version info file in the the S3 bucket.") ) )
-  <> ( command "generate"
-       (info ((UpdateProposalCommand <$> date <*> pure UpdateProposalGenerate) <**> helper)
-         (progDesc "Create a voting transaction") ) )
   <> ( command "submit"
        (info (UpdateProposalCommand <$> date <*> (UpdateProposalSubmit <$> relayIP <*> dryRun <*> withSystems))
-         (progDesc "Send update proposal transaction to the network") ) )
+         (progDesc "Send update proposal voting transaction to the network.") ) )
   where
     mdate :: Parser (Maybe Text)
     mdate = fmap (fmap fromString) . optional . argument str $
@@ -156,10 +152,10 @@ updateProposal o cfg cmd = do
         UpdateProposalSignInstallers userId -> updateProposalSignInstallers opts userId
         UpdateProposalUploadS3 -> updateProposalUploadS3 cfg opts
         UpdateProposalSetVersionJSON -> updateProposalSetVersionJSON cfg opts
-        UpdateProposalGenerate -> updateProposalGenerate opts
-        UpdateProposalSubmit relay dryRun systems ->
+        UpdateProposalSubmit relay dryRun systems -> do
+          updateProposalGenerate opts
           let opts' = opts { cmdRelayIP = Just relay, cmdDryRun = dryRun }
-          in updateProposalSubmit opts' systems
+          updateProposalSubmit opts' systems
 
 ----------------------------------------------------------------------------
 -- Parameters files. These are loaded/saved to yaml in the work dir.
@@ -602,7 +598,8 @@ updateProposalSetVersionJSON cfg opts@CommandOptions{..} = do
 
 ----------------------------------------------------------------------------
 
--- | Step 4. Generate database with keys, download installers.
+-- | Step 4a. Check installer file types, copy into place, generate
+-- database with keys.
 updateProposalGenerate :: CommandOptions -> Shell ()
 updateProposalGenerate opts@CommandOptions{..} = do
   params@UpdateProposalConfig3{..} <- loadParams opts
@@ -614,7 +611,6 @@ updateProposalGenerate opts@CommandOptions{..} = do
   addrs <- doGenerate opts params
   storeParams opts (UpdateProposalConfig4 params addrs)
   echo "*** Finished generate step. Next step is to submit."
-  echo "*** Carefully check the parameters yaml file."
 
 -- | Partition CI results by arch.
 groupResults :: InstallersResults -> ArchMap [CIResult]
@@ -668,7 +664,7 @@ doGenerate opts UpdateProposalConfig3{..} = do
 
 ----------------------------------------------------------------------------
 
--- | Step 5. Submit update proposal.
+-- | Step 4b. Submit update proposal.
 updateProposalSubmit :: CommandOptions -> ArchMap Bool -> Shell ()
 updateProposalSubmit opts@CommandOptions{..} systems = do
   echo "*** Submitting update proposal"

--- a/iohk/UpdateProposal.hs
+++ b/iohk/UpdateProposal.hs
@@ -679,7 +679,7 @@ doPropose :: CommandOptions -> UpdateProposalConfig4 -> ArchMap Bool -> Shell (M
 doPropose opts cfg systems = fold (runCommands opts [cmd] & grep isUpdateId) Fold.last
   where
     cmd = proposeUpdateCmd opts cfg systems
-    isUpdateId = count 64 hexDigit
+    isUpdateId = has (text "upId: " *> hash256Hex)
 
 proposeUpdateCmd :: CommandOptions -> UpdateProposalConfig4 -> ArchMap Bool -> Text
 proposeUpdateCmd opts cfg systems = format

--- a/iohk/common/Arch.hs
+++ b/iohk/common/Arch.hs
@@ -37,7 +37,6 @@ formatArch Mac64 = "macOS"
 formatArch Win64 = "Windows"
 
 -- | A map of values indexed by Arch.
--- Maybe "type ArchMap a = Arch -> a" would be better but this works.
 data ArchMap a = ArchMap { linux64 :: !a, mac64 :: !a, win64 :: !a }
   deriving (Show, Read, Eq, Generic, Functor, Foldable, Traversable)
 

--- a/iohk/common/NixOps.hs
+++ b/iohk/common/NixOps.hs
@@ -897,9 +897,11 @@ configurationKeys Testnet    Mac64   = "testnet_wallet_macos64"
 configurationKeys Testnet    Linux64 = "testnet_wallet_linux64"
 configurationKeys env _ = error $ "Application versions not used in '" <> show env <> "' environment"
 
-findInstallers :: NixopsConfig -> T.Text -> Maybe FilePath -> IO ()
-findInstallers c daedalusRev destDir = do
-  installers <- getInstallersResults (configurationKeys $ cEnvironment c) (const True) daedalusRev destDir
+findInstallers :: NixopsConfig -> T.Text -> Maybe FilePath
+               -> Maybe Int -> Maybe Int -> IO ()
+findInstallers c daedalusRev destDir bkNum avNum = do
+  let instP = selectBuildNumberPredicate bkNum avNum
+  installers <- getInstallersResults (configurationKeys $ cEnvironment c) instP daedalusRev destDir
   printInstallersResults installers
   case destDir of
     Just dir -> void $ proc "ls" [ "-ltrha", tt dir ] mempty

--- a/iohk/common/UpdateLogic.hs
+++ b/iohk/common/UpdateLogic.hs
@@ -11,6 +11,9 @@
 module UpdateLogic
   ( getInstallersResults
   , realFindInstallers
+  , InstallerPredicate
+  , selectBuildNumberPredicate
+  , installerPredicates
   , CIResult(..)
   , uploadHashedInstaller
   , uploadSignature
@@ -43,7 +46,7 @@ import           Control.Applicative          ((<|>))
 import           Control.Exception            (try)
 import           Control.Lens                 (to, (^.))
 import qualified Control.Lens                 as Lens
-import           Control.Monad                (guard, when, (<=<))
+import           Control.Monad                (guard, when, (<=<), mapM_, forM_)
 import           Control.Monad.IO.Class       (liftIO)
 import           Control.Monad.Trans.Resource (runResourceT)
 import           Data.Aeson                   (ToJSON, FromJSON)
@@ -98,7 +101,7 @@ data CIResult = CIResult
   , ciResultSHA1Sum     :: Maybe Text
   } deriving (Show, Generic)
 
-data CISystem = Buildkite | AppVeyor deriving (Show, Generic)
+data CISystem = Buildkite | AppVeyor deriving (Show, Eq, Bounded, Enum, Generic)
 
 data InstallersResults = InstallersResults
   { ciResults    :: [CIResult]
@@ -114,6 +117,22 @@ instance ToJSON CISystem
 
 -- | Allow selection of which CI artifacts to download.
 type InstallerPredicate = CIResult -> Bool
+
+-- | An 'InstallerPredicate' which filters by build numbers from the
+-- CI system. Useful when the CI has multiple builds for a single git
+-- revision. 'Nothing' designates no filter.
+selectBuildNumberPredicate :: Maybe Int -- ^ Buildkite build number
+                           -> Maybe Int -- ^ AppVeyor build number
+                           -> InstallerPredicate
+selectBuildNumberPredicate bk av =
+  installerPredicates (buildNum Buildkite bk) (buildNum AppVeyor av)
+  where
+    buildNum ci Nothing    _ = True
+    buildNum ci (Just num) r = ciResultSystem r /= ci || ciResultBuildNumber r == num
+
+-- | Joins two installer predicates so that both must be satisfied.
+installerPredicates :: InstallerPredicate -> InstallerPredicate -> InstallerPredicate
+installerPredicates p q a = p a && q a
 
 -- | Read the Buildkite token from a config file. This file is not
 -- checked into git, so the user needs to create it themself.
@@ -141,13 +160,14 @@ realFindInstallers :: InstallerPredicate -> Rev -> Maybe FilePath -> IO [CIResul
 realFindInstallers instP daedalusRev destDir = do
   buildkiteToken <- liftIO $ loadBuildkiteToken
   st <- liftIO $ statuses <$> fetchGithubStatus "input-output-hk" "daedalus" daedalusRev
-  let find = handleCIResults instP destDir <=< findInstallersFromStatus buildkiteToken destDir
-  concat <$> mapM find st
+  let findStatus = handleCIResults instP destDir <=< findInstallersFromStatus buildkiteToken destDir
+  concat <$> mapM findStatus st
 
 getInstallersResults :: ApplicationVersionKey -> InstallerPredicate -> Rev -> Maybe FilePath -> IO InstallersResults
 getInstallersResults keys instP daedalusRev destDir = do
   ciResults <- realFindInstallers instP daedalusRev destDir
   globalResult <- findVersionInfo keys daedalusRev
+  validateCIResultCount ciResults
   pure $ InstallersResults ciResults globalResult
 
 handleCIResults :: InstallerPredicate -> Maybe FilePath -> Either Text [CIResult] -> IO [CIResult]
@@ -156,6 +176,22 @@ handleCIResults instP destDir (Right rs) = do
   when (isJust destDir) $ fetchCIResults rs'
   pure rs'
 handleCIResults _ _ (Left msg) = T.putStrLn msg >> pure []
+
+validateCIResultCount :: [CIResult] -> IO ()
+validateCIResultCount rs = forM_ (ciResultsBySystem rs) $ \(ci, rs') -> let
+  urls = nub $ map ciResultUrl rs'
+  in case length urls of
+       0 -> printf ("warning: There are no CI results for "%w%"!\n") ci
+       1 -> printf ("Found a single CI result for "%w%".\n") ci
+       n -> do
+         printf ("error: Found too many ("%d%") CI results for "%w%"!\n") n ci
+         printf "The following builds were found:\n"
+         forM_ urls $ printf ("  "%s%"\n")
+         die $ format ("Use the --"%w%"-build-num option to choose one.\nExiting.") ci
+
+ciResultsBySystem :: [CIResult] -> [(CISystem, [CIResult])]
+ciResultsBySystem rs = [ (ci, filter ((== ci) . ciResultSystem) rs)
+                       | ci <- enumFromTo minBound maxBound ]
 
 buildkiteOrg     = "input-output-hk" :: Text
 pipelineDaedalus = "daedalus"        :: Text


### PR DESCRIPTION
https://iohk.myjetbrains.com/youtrack/issue/DEVOPS-868

* Makes the _date_ argument to `io update-proposal` commands compulsory to avoid problems running the procedure around UTC midnight.
* Roll the `generate` step into `submit`.
* Fix pattern matching of the update proposal ID which got broken by cardano-sl 1.3.0.
* Require a single CI build per commit. If there is more than one build found (e.g. due to multiple pull requests for the same revision), then the user has to provide a build number.
