### PR TITLE
[DEVOPS-398] cardano-explorer: enable HTTPS

### DIFF
--- a/deployments/security-groups.nix
+++ b/deployments/security-groups.nix
@@ -118,6 +118,10 @@ with import ../lib.nix;
                 protocol = "tcp";
                 fromPort = 80; toPort = 80;
                 sourceIp = "0.0.0.0/0";
+              } {
+                protocol = "tcp";
+                fromPort = 443; toPort = 443;
+                sourceIp = "0.0.0.0/0";
               }];
             };
             "allow-to-faucet-${region}" = {

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -13,7 +13,7 @@ in
   services.cardano-node.executable = "${explorer-drv}/bin/cardano-explorer";
 
   networking.firewall.allowedTCPPorts = [
-    80 # nginx
+    80 443 # nginx
   ];
 
   services.nginx = {
@@ -23,7 +23,8 @@ in
                            then config.global.dnsDomainname else "iohkdev.io";
      in {
       "cardano-explorer.${vhostDomainName}" = {
-        # TLS provided by cloudfront
+        enableACME = true;
+        addSSL = true;
         locations = {
           "/" = {
             root = cardanoPackages.cardano-sl-explorer-frontend;


### PR DESCRIPTION
Enable acme and https for NGINX which proxies cardano-explorer.

This is required for putting explorer in an iframe on a HTTPS website.

Mainnet explorer can still use cloudflare.