### PR TITLE
Fix config parsing

### DIFF
--- a/iohk/common/NixOps.hs
+++ b/iohk/common/NixOps.hs
@@ -377,7 +377,7 @@ instance FromJSON NixopsConfig where
         <*> v .: "environment"
         <*> v .: "target"
         <*> v .: "installer-bucket"
-        <*> v .: "installer-url-base" .!= "--unspecified--"
+        <*> v .: "installer-url-base"
         <*> v .: "elements"
         <*> v .: "files"
         <*> v .: "args"
@@ -442,7 +442,7 @@ mkNewConfig o cGenCmdline cName                       mTopology cEnvironment cTa
       cFiles          = deploymentFiles                         cEnvironment cTarget cElements
       cTopology       = flip fromMaybe                mTopology envDefaultTopology
       cUpdateBucket   = "default-bucket"
-      cInstallerURLBase = "--undefined--"
+      cInstallerURLBase = Nothing
   cDeplArgs <- selectInitialConfigDeploymentArgs o cTopology cEnvironment         cElements systemStart mConfigurationKey
   topology  <- getSimpleTopo cElements cTopology
   nixpkgs   <- Path.fromText <$> incmdStrip o "nix-build" ["--no-out-link", "fetch-nixpkgs.nix"]

--- a/iohk/common/Types.hs
+++ b/iohk/common/Types.hs
@@ -193,7 +193,7 @@ data NixopsConfig = NixopsConfig
   , cEnvironment      :: Environment
   , cTarget           :: Target
   , cUpdateBucket     :: Text
-  , cInstallerURLBase :: Text
+  , cInstallerURLBase :: Maybe Text
   , cElements         :: [Deployment]
   , cFiles            :: [Text]
   , cDeplArgs         :: DeplArgs

--- a/iohk/common/UpdateLogic.hs
+++ b/iohk/common/UpdateLogic.hs
@@ -133,7 +133,8 @@ loadBuildkiteToken = try (T.readFile buildkiteTokenFile) >>= \case
     st = makeFormat T.pack
 
 cdnLink :: HasCallStack => NixopsConfig -> ObjectKey -> Text
-cdnLink NixopsConfig{..} (ObjectKey key) = mconcat [ "https://", cInstallerURLBase, "/", key ]
+cdnLink NixopsConfig{cInstallerURLBase=Nothing, ..} _ = error "installer-url-base is required in the configuration YAML file, but was not specified"
+cdnLink NixopsConfig{cInstallerURLBase=Just cInstallerURLBase, ..} (ObjectKey key) = mconcat [ "https://", cInstallerURLBase, "/", key ]
 
 buildkiteTokenFile = "static/buildkite_token" :: String
 

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@ let
   iohkpkgs = import ./default.nix {};
   iohk-ops = iohkpkgs.iohk-ops;
   justIo = pkgs.runCommand "shell" {
-    buildInputs = with pkgs; [ iohk-ops terraform_0_11 iohkpkgs.nixops ];
+    buildInputs = with pkgs; [ iohk-ops terraform_0_11 iohkpkgs.nixops cabal-install ];
     passthru = {
       inherit ioSelfBuild withAuxx;
     };


### PR DESCRIPTION
This fixes the unfortunate problem of `installer-uri-base` being required even in the cases where it's not needed.