### PR TITLE
[DEVOPS-1039] add influxdb/grafana and clean up nginx config for hydra

### DIFF
--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -314,6 +314,7 @@ runNew o@Options{..} New{..} args = do
     let secrets = [ "static/github_token"
                   , "static/id_buildfarm"
                   , "static/datadog-api.secret"
+                  , "static/google_oauth_hydra_grafana.secret"
                   , "static/datadog-application.secret"
                   , "static/zendesk-token.secret" ]
     forM_ secrets touch


### PR DESCRIPTION
Adds grafana and influxdb to hydra master. Cleans up nginx to make it easier to work with in the future. grafana should have google oauth support, although untested as of yet.