### PR TITLE
[DEVOPS-1033] potentially fix missing cached builds in github

### DIFF
--- a/modules/hydra-lowest.patch
+++ b/modules/hydra-lowest.patch
@@ -1,0 +1,13 @@
+diff --git a/src/script/hydra-eval-jobset b/src/script/hydra-eval-jobset
+index 9d375c1b..711a1df4 100755
+--- a/src/script/hydra-eval-jobset
++++ b/src/script/hydra-eval-jobset
+@@ -746,7 +746,7 @@ sub checkJobsetWrapped {
+             # Wake up hydra-queue-runner.
+             my $lowestId;
+             while (my ($id, $x) = each %buildMap) {
+-                $lowestId = $id if $x->{new} && (!defined $lowestId || $id < $lowestId);
++                $lowestId = $id if (!defined $lowestId || $id < $lowestId);
+             }
+             $notifyAdded->execute($lowestId) if defined $lowestId;
+ 

--- a/modules/hydra-master-common.nix
+++ b/modules/hydra-master-common.nix
@@ -12,6 +12,7 @@ let
         ./hydra-nix-prefetch-git.patch
         ./hydra-not-found.patch
         ./hydra-github-pr-filter.patch
+        ./hydra-lowest.patch
       ] ++ (lib.optional hydraExtraDebug ./hydra-extra-debug.patch);
     });
   };


### PR DESCRIPTION
https://github.com/NixOS/hydra/commit/dc5e0b120aac06f1c46bcf0296d14775d72c2354#diff-fa352a753d5c2e84da9af5fa5e5f2e35R729

i believe the above commit, causes `hydra-queue-runner` to never load builds that are reusing a build# from a past eval
and as a result, it never runs the `hydra-notify` again for that build#, (which would notice its a member of a new eval and update properly)
removing the limitation on new builds should prevent the bug