### PR TITLE
[DEVOPS-1022] nix-darwin: Also do periodic GC

### DIFF
--- a/nix-darwin/modules/basics.nix
+++ b/nix-darwin/modules/basics.nix
@@ -4,6 +4,8 @@ let
   opsLib = import ../../lib.nix;
 
 in {
+  imports = [ ./double-builder-gc.nix ];
+
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
@@ -36,12 +38,6 @@ in {
   nix.extraOptions = ''
     gc-keep-derivations = true
     gc-keep-outputs = true
-
-    # Try to ensure between 1000M and 25000M of free space by
-    # automatically triggering a garbage collection if free
-    # disk space drops below a certain level during a build.
-    min-free = 1048576000
-    max-free = 26214400000
   '';
 
   nix.binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];

--- a/nix-darwin/modules/double-builder-gc.nix
+++ b/nix-darwin/modules/double-builder-gc.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+let
+  maxFreedMB = 25000;
+  minFreeMB = 2000;
+
+in {
+  imports = [ ../services/builder-gc.nix ];
+
+  # This GC is run automatically by nix-build
+  nix.extraOptions = ''
+    # Try to ensure between ${toString minFreeMB}M and ${toString maxFreedMB}M of free space by
+    # automatically triggering a garbage collection if free
+    # disk space drops below a certain level during a build.
+    min-free = ${toString (minFreeMB * 1048576)}
+    max-free = ${toString (maxFreedMB * 1048576)}
+  '';
+
+  # This GC is run on 15 minute intervals
+  nix.builder-gc = {
+    enable = true;
+    inherit maxFreedMB minFreeMB;
+  };
+}

--- a/nix-darwin/services/builder-gc.nix
+++ b/nix-darwin/services/builder-gc.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.nix.builder-gc;
+in
+
+{
+  options = {
+    nix.builder-gc.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Automatically run the garbage collector when free disk space
+        falls below a certain level.
+      '';
+    };
+
+    nix.builder-gc.interval = mkOption {
+      type = types.listOf types.attrs;
+      default = map (m: { Minute = m; }) [ 0 15 30 45 ];
+      description = "The time interval at which the garbage collector will run.";
+    };
+
+    nix.builder-gc.maxFreedMB = mkOption {
+      type = types.int;
+      example = 25 * 1024;
+      description = ''
+        Approximate maximum amount in megabytes to delete.
+        This is given as the <filename>nix-collect-garbage --max-freed</filename>
+        argument when the garbage collector is run automatically.
+      '';
+    };
+
+    nix.builder-gc.minFreeMB = mkOption {
+      type = types.int;
+      example = 1024;
+      description = ''
+        Low disk level in megabytes which triggers garbage collection.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    launchd.daemons.nix-builder-gc = {
+      script = ''
+        free=$(${pkgs.coreutils}/bin/df --block-size=M --output=avail /nix/store | tail -n1 | sed s/M//)
+        echo "Automatic GC: ''${free}M available"
+        if [ $free -lt ${toString cfg.minFreeMB} ]; then
+          ${config.nix.package}/bin/nix-collect-garbage --max-freed ${toString (cfg.maxFreedMB * 1024 * 1024)}
+        fi
+      '';
+      environment.NIX_REMOTE = lib.optionalString config.services.nix-daemon.enable "daemon";
+      serviceConfig.RunAtLoad = false;
+      serviceConfig.StartCalendarInterval = cfg.interval;
+    };
+  };
+}


### PR DESCRIPTION
The Nix min-free setting seems to be unreliable.

Add back GC at quarter-hour intervals.

Increase the minimum to 2000MB.