### PR TITLE
[DEVOPS-1044] bors: Add hydra jobs to required checks

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,8 @@
 status = [
   "buildkite/iohk-ops",
+  "ci/hydra:serokell:iohk-nixops:iohk-ops.x86_64-linux",
+  "ci/hydra:serokell:iohk-nixops:iohk-ops-integration-test.x86_64-linux",
+  "ci/hydra:serokell:iohk-nixops:checks.shellcheck",
 ]
 timeout_sec = 7200
 required_approvals = 1

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -47,7 +47,7 @@ let
     };
   };
   makeNixopsPR = num: info: {
-    name = "iohk-nixops-${num}";
+    name = "iohk-nixops-pr-${num}";
     value = defaultSettings // {
       description = "PR ${num}: ${info.title}";
       nixexprpath = "jobsets/cardano.nix";
@@ -133,6 +133,8 @@ let
     daedalus = mkDaedalus "develop";
     plutus = mkPlutus "master";
     iohk-nixops = mkNixops "master" nixpkgs-src.rev;
+    iohk-nixops-bors-staging = mkNixops "bors-staging" nixpkgs-src.rev;
+    iohk-nixops-bors-trying = mkNixops "bors-trying" nixpkgs-src.rev;
   });
   jobsetsAttrs = daedalusPrJobsets // nixopsPrJobsets // plutusPrJobsets // (if handleCardanoPRs then cardanoPrJobsets else {}) // mainJobsets;
   jobsetJson = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);

--- a/modules/hydra-github-pr-filter.patch
+++ b/modules/hydra-github-pr-filter.patch
@@ -6,7 +6,7 @@ index 08ba25bb..5fa8c3fe 100644
              next if !$finished && $b->finished == 1;
  
              my $contextTrailer = $conf->{excludeBuildFromContext} ? "" : (":" . $b->id);
-+            my $github_job_name = $jobName =~ s/-pr-\d+//r;
++            my $github_job_name = $jobName =~ s/-(pr-\d+|bors-(staging|trying))//r;
              my $body = encode_json(
                  {
                      state => $finished ? toGithubState($b->buildstatus) : "pending",


### PR DESCRIPTION
To get hydra checks working with bors-ng in iohk-ops:
1. The CI status entries on GitHub must have the same name -- whether PR, staging branch, or master.
     - So adjust our magic regexp to remove `bors-(staging|trying)` branch names from github status entries
     - Adjust the iohk-nixops PR jobset names so that the magic regexp applies.
2. `bors.toml` must have the job names listed.
3. The `bors-staging` and `bors-trying` branches need to be built automatically by Hydra.
