### PR TITLE
[DEVOPS-998] Update cardano-sl to latest release/1.3.1

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "74402ed249f749f0c45f0399f2dd155605865a5d",
-  "sha256": "0msdg16c5sm3dj9b4xj6p2ks92i2db394p76dyv08a8m04ji11i2",
-  "fetchSubmodules": "true"
+  "rev": "3fa92ec1588c1b0849be477b4abf1fa652aa842d",
+  "sha256": "02lgzhncbd80zmppw99016w0ya3mqjl9xjyna5z3rs3sid671yci",
+  "fetchSubmodules": false
 }


### PR DESCRIPTION
Updates nixops deployments to use latest release/1.3.1.
Merge when ready to deploy on staging.
