### PR TITLE
[DEVOPS-1071] iohk-nixops → iohk-ops

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,8 @@
 status = [
   "buildkite/iohk-ops",
-  "ci/hydra:serokell:iohk-nixops:iohk-ops.x86_64-linux",
-  "ci/hydra:serokell:iohk-nixops:iohk-ops-integration-test.x86_64-linux",
-  "ci/hydra:serokell:iohk-nixops:checks.shellcheck",
+  "ci/hydra:serokell:iohk-ops:iohk-ops.x86_64-linux",
+  "ci/hydra:serokell:iohk-ops:iohk-ops-integration-test.x86_64-linux",
+  "ci/hydra:serokell:iohk-ops:checks.shellcheck",
 ]
 timeout_sec = 7200
 required_approvals = 1

--- a/iohk/common/Constants.hs
+++ b/iohk/common/Constants.hs
@@ -51,7 +51,7 @@ data Project
 
 projectURL     :: Project -> URL
 projectURL     CardanoSL       = "https://github.com/input-output-hk/cardano-sl"
-projectURL     IOHKOps         = "https://github.com/input-output-hk/iohk-nixops"
+projectURL     IOHKOps         = "https://github.com/input-output-hk/iohk-ops"
 projectURL     Nixpkgs         = "https://github.com/nixos/nixpkgs"
 projectURL     Stack2nix       = "https://github.com/input-output-hk/stack2nix"
 projectURL     Nixops          = "https://github.com/input-output-hk/nixops"

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -15,7 +15,7 @@ let
   daedalusPrs = builtins.fromJSON (builtins.readFile daedalusPrsJSON);
   plutusPrs = builtins.fromJSON (builtins.readFile plutusPrsJSON);
 
-  iohkNixopsUri = "https://github.com/input-output-hk/iohk-nixops.git";
+  iohkOpsURI = "https://github.com/input-output-hk/iohk-ops.git";
   mkFetchGithub = value: {
     inherit value;
     type = "git";
@@ -32,22 +32,22 @@ let
     checkinterval = 60;
     inputs = {
       nixpkgs = mkFetchGithub "https://github.com/NixOS/nixpkgs.git ${nixpkgs-src.rev}";
-      jobsets = mkFetchGithub "${iohkNixopsUri} master";
+      jobsets = mkFetchGithub "${iohkOpsURI} master";
     };
     enableemail = false;
     emailoverride = "";
   };
   mkNixops = nixopsBranch: nixpkgsRev: {
     nixexprpath = "jobsets/cardano.nix";
-    description = "IOHK-nixops";
+    description = "IOHK-Ops";
     inputs = {
       nixpkgs = mkFetchGithub "https://github.com/NixOS/nixpkgs.git ${nixpkgsRev}";
-      jobsets = mkFetchGithub "${iohkNixopsUri} ${nixopsBranch}";
+      jobsets = mkFetchGithub "${iohkOpsURI} ${nixopsBranch}";
       nixops = mkFetchGithub "https://github.com/NixOS/NixOps.git tags/v1.5";
     };
   };
   makeNixopsPR = num: info: {
-    name = "iohk-nixops-pr-${num}";
+    name = "iohk-ops-pr-${num}";
     value = defaultSettings // {
       description = "PR ${num}: ${info.title}";
       nixexprpath = "jobsets/cardano.nix";
@@ -132,9 +132,9 @@ let
     cardano-sl-1-3 = mkCardano "release/1.3.1";
     daedalus = mkDaedalus "develop";
     plutus = mkPlutus "master";
-    iohk-nixops = mkNixops "master" nixpkgs-src.rev;
-    iohk-nixops-bors-staging = mkNixops "bors-staging" nixpkgs-src.rev;
-    iohk-nixops-bors-trying = mkNixops "bors-trying" nixpkgs-src.rev;
+    iohk-ops = mkNixops "master" nixpkgs-src.rev;
+    iohk-ops-bors-staging = mkNixops "bors-staging" nixpkgs-src.rev;
+    iohk-ops-bors-trying = mkNixops "bors-trying" nixpkgs-src.rev;
   });
   jobsetsAttrs = daedalusPrJobsets // nixopsPrJobsets // plutusPrJobsets // (if handleCardanoPRs then cardanoPrJobsets else {}) // mainJobsets;
   jobsetJson = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -12,7 +12,7 @@
     "inputs": {
          "src": { "type": "git", "value": "https://github.com/input-output-hk/iohk-ops.git master", "emailresponsible": false }
          ,"nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs-channels.git nixos-16.09", "emailresponsible": false }
-         ,"nixopsPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-nixops", "emailresponsible": false }
+         ,"nixopsPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-ops", "emailresponsible": false }
          ,"cardanoPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-sl", "emailresponsible": false }
          ,"daedalusPrsJSON": { "type": "githubpulls", "value": "input-output-hk daedalus", "emailresponsible": false }
          ,"plutusPrsJSON": { "type": "githubpulls", "value": "input-output-hk plutus", "emailresponsible": false }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -68,7 +68,7 @@ in {
         input-output-hk = ${builtins.readFile ../static/github_token}
       </github_authorization>
       <githubstatus>
-        jobs = serokell:iohk-nixops.*
+        jobs = serokell:iohk-ops.*
         inputs = jobsets
         excludeBuildFromContext = 1
         useShortContext = 1


### PR DESCRIPTION
The repo used to be at this URL, but no longer: https://github.com/input-output-hk/iohk-nixops

This change will fix GitHub CI status updates for the master branch.