### PR TITLE
[DEVOPS-1078] nix-darwin: increase GC min-free to 6GB

### DIFF
--- a/nix-darwin/modules/double-builder-gc.nix
+++ b/nix-darwin/modules/double-builder-gc.nix
@@ -2,7 +2,7 @@
 
 let
   maxFreedMB = 25000;
-  minFreeMB = 2000;
+  minFreeMB = 6000;
 
 in {
   imports = [ ../services/builder-gc.nix ];


### PR DESCRIPTION
Due to the size of our builds, 2GB min-free is not enough to avoid running out of space.