### PR TITLE
infra: Provide minimal build environment for buildkite-agent

### DIFF
--- a/modules/buildkite-agent.nix
+++ b/modules/buildkite-agent.nix
@@ -14,10 +14,16 @@
     openssh.publicKeyPath  = "/run/keys/buildkite-ssh-public";
     tokenPath              = "/run/keys/buildkite-token";
     meta-data              = "system=x86_64-linux";
-    runtimePackages        = with pkgs; [ bash gnutar gzip bzip2 xz nix ];
+    runtimePackages        = with pkgs; [
+       bash gnutar gzip bzip2 xz
+       git git-lfs
+       nix
+    ];
     hooks.environment = ''
+      # Provide a minimal build environment
       export NIX_BUILD_SHELL="/run/current-system/sw/bin/bash"
       export PATH="/run/current-system/sw/bin:$PATH"
+      export NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
 
       # load S3 credentials for artifact upload
       source /var/lib/buildkite-agent/hooks/aws-creds

--- a/nix-darwin/modules/buildkite-agent.nix
+++ b/nix-darwin/modules/buildkite-agent.nix
@@ -15,7 +15,11 @@ in {
   in {
     enable = true;
     package = unstablePkgs.buildkite-agent3;
-    runtimePackages = with pkgs; [ bash nix git ];
+    runtimePackages = with pkgs; [
+      bash gnutar gzip bzip2 xz
+      git git-lfs
+      nix
+    ];
     meta-data = "system=x86_64-darwin";
     tokenPath = "${keys}/buildkite_token";
     openssh.privateKeyPath = "${keys}/id_buildkite";
@@ -29,8 +33,9 @@ in {
       fi
     '';
     hooks.environment = ''
-      export NIX_REMOTE=daemon
+      # Provide a minimal build environment
       export NIX_BUILD_SHELL="/run/current-system/sw/bin/bash"
+      export NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
       # /usr/bin and /usr/sbin are added For iconutil, security, pkgutil, etc.
       # Required for daedalus installer build,
       # or any build which expects to have apple tools.


### PR DESCRIPTION
Provide git-lfs in the Buildkite environment so that LFS repos can be cloned from GitHub.

Set the NIX_PATH for the builds to be what's running on the buildkite-agent system. Mostly, our builds will be pinning the nixpkgs version, so this is usually irrelevant. But sometimes it's helpful to be able to use a nix package from the host system's package set. For example, docker.