### PR TITLE
[DEVOPS-1123] testnet: Add monitor for faucet balance

### DIFF
--- a/deployments/cardano-faucet-env-testnet.nix
+++ b/deployments/cardano-faucet-env-testnet.nix
@@ -14,6 +14,18 @@ let nodeMap = { inherit (globals.fullMap) faucet; }; in
           ok = 1;
         };
       });
+
+      cardano_faucet_balance_monitor = let
+        critical = "10000000000"; # amounts in lovelace, average withdrawal is 1000 ada
+      in mkMonitor {
+        name = "Testnet faucet wallet balance is low";
+        type = "metric alert";
+        query = config: "max(last_5m):avg:faucet.wallet_balance{depl:${config.deployment.name}} by {host} <= ${critical}";
+        monitorOptions.thresholds = {
+          warning = "100000000000";
+          inherit critical;
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
Tested by deploying on testnet, with datadog downtime enabled, with the warning threshold tweaked 100x.
