### PR TITLE
[DEVOPS-1141] io find-installers: fix --download short option

### DIFF
--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -240,7 +240,7 @@ centralCommandParser =
        (FindInstallers
         <$> option str (long "daedalus-rev" <> short 'r' <> metavar "SHA1")
         <*> optional (fromText <$> option auto
-                       (long "download" <> short 'r' <> metavar "DIRECTORY"
+                       (long "download" <> short 'd' <> metavar "DIRECTORY"
                         <> help "Download the found installers to the given directory."
                         <> completer (bashCompleter "directory")))
         <*> optional (option auto (long "buildkite-build-num" <> metavar "NUMBER"))


### PR DESCRIPTION
Copy&paste error -- it was -r instead of -d.