### PR TITLE
[DEVOPS-1143]  bump cardano-sl for report-server

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "02b278d0a4b133c3ed11c98bc12db9644d4462cb",
-  "sha256": "10xg0mpl71b8yz827rd1y5jyqmlapl983x3d6d2lw5h4l6i4312q",
+  "rev": "23d0c7873a044d5e4fc883eaf1a85960558a766f",
+  "sha256": "0mahdsjs7ardkqfzgnzg6zhh98lnnf6g50yqqqlj5jmsini6wf5h",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This will allow us to deploy https://github.com/input-output-hk/cardano-report-server/pull/25