### PR TITLE
[DEVOPS-1179] jobsets: Clean up and add jobset for cardano-wallet

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -91,7 +91,7 @@ let
     };
 
     cardano-wallet = {
-      description = "Cardano Wallet";
+      description = "Cardano Wallet Backend";
       url = "https://github.com/input-output-hk/cardano-wallet.git";
       branch = "develop";
       prs = walletPrsJSON;
@@ -163,7 +163,7 @@ let
       mkJobset { name = "${name}-${suffix}"; inherit description url input branch; });
 
   # Make a jobset for a GitHub PRs
-  mkJobsetPR = { name, description, input, modifier }: num: info: {
+  mkJobsetPR = { name, input, modifier }: num: info: {
     name = "${name}-pr-${num}";
     value = defaultSettings // modifier {
       description = "PR ${num}: ${info.title}";
@@ -176,9 +176,9 @@ let
   };
 
   # Load the PRs json and make a jobset for each
-  mkJobsetPRs = { name, description, input, modifier, prs }:
+  mkJobsetPRs = { name, input, modifier, prs }:
     mapAttrsToList
-      (mkJobsetPR { inherit name description input modifier; })
+      (mkJobsetPR { inherit name input modifier; })
       (loadPrsJSON prs);
 
   # Add two extra jobsets for the bors staging and trying branches
@@ -199,7 +199,7 @@ let
     in
       [ (mkJobset (params // { inherit branch; })) ] ++
       (mkJobsetBranches params (info.branches or {})) ++
-      (mkJobsetPRs { inherit name input; inherit (info) description prs; modifier = prJobsetModifier; }) ++
+      (mkJobsetPRs { inherit name input; inherit (info) prs; modifier = prJobsetModifier; }) ++
       (optionals (info.bors or false) (mkJobsetBors params));
   in
     rs: listToAttrs (concatLists (mapAttrsToList mkRepo rs));

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -1,34 +1,111 @@
-{ nixopsPrsJSON ? ./simple-pr-dummy.json
+############################################################################
+# This is the jobset declaration evaluated by Hydra to dynamically
+# generate jobsets.
+#
+# The arguments for this file come from spec.json.
+#
+# See also the Hydra manual:
+#   https://github.com/NixOS/hydra/blob/master/doc/manual/declarative-projects.xml
+#
+############################################################################
+
+{ nixpkgs ? <nixpkgs>
+, declInput ? {}
+
+# Paths to JSON files containing PR info fetched from github.
+# An example file is ./simple-pr-dummy.json.
+, nixopsPrsJSON ? ./simple-pr-dummy.json
 , cardanoPrsJSON ? ./simple-pr-dummy.json
 , daedalusPrsJSON ? ./simple-pr-dummy.json
 , plutusPrsJSON ? ./simple-pr-dummy.json
 , logClassifierPrsJSON ? ./simple-pr-dummy.json
 , ouroborosNetworkPrsJSON ? ./simple-pr-dummy.json
 , chainPrsJSON ? ./simple-pr-dummy.json
-, nixpkgs ? <nixpkgs>
-, declInput ? {}
-, handleCardanoPRs ? true
+, walletPrsJSON ? ./simple-pr-dummy.json
 }:
 
-# Followed by https://github.com/NixOS/hydra/pull/418/files
+let pkgs = import nixpkgs {}; in
+
+with pkgs.lib;
 
 let
-  nixopsPrs = builtins.fromJSON (builtins.readFile nixopsPrsJSON);
-  cardanoPrs = builtins.fromJSON (builtins.readFile cardanoPrsJSON);
-  daedalusPrs = builtins.fromJSON (builtins.readFile daedalusPrsJSON);
-  plutusPrs = builtins.fromJSON (builtins.readFile plutusPrsJSON);
-  logClassifierPrs = builtins.fromJSON (builtins.readFile logClassifierPrsJSON);
-  ouroborosNetworkPrs = builtins.fromJSON (builtins.readFile ouroborosNetworkPrsJSON);
-  chainPrs = builtins.fromJSON (builtins.readFile chainPrsJSON);
 
-  iohkOpsURI = "https://github.com/input-output-hk/iohk-ops.git";
+  ##########################################################################
+  # GitHub repos to make jobsets for.
+  # These are processed by the mkRepoJobsets function below.
+
+  repos = {
+    cardano-sl = {
+      description = "Cardano SL";
+      url = "https://github.com/input-output-hk/cardano-sl.git";
+      input = "cardano";  # corresponds to argument in cardano-sl/release.nix
+      branch = "develop";
+      branches = {
+        master = "master";
+        "1-0" = "release/1.0.x";
+        "1-2" = "release/1.2.0";
+        "1-3" = "release/1.3.1";
+        "2-0" = "release/2.0.0";
+      };
+      prs = cardanoPrsJSON;
+      prJobsetModifier = withFasterBuild;
+      bors = true;
+    };
+
+    daedalus = {
+      description = "Daedalus Wallet";
+      url = "https://github.com/input-output-hk/daedalus.git";
+      branch = "develop";
+      prs = daedalusPrsJSON;
+      bors = true;
+    };
+
+    plutus = {
+      description = "Plutus Language";
+      url = "https://github.com/input-output-hk/plutus.git";
+      prs = plutusPrsJSON;
+    };
+
+    log-classifier = {
+      description = "Log Classifier";
+      url = "https://github.com/input-output-hk/log-classifier.git";
+      prs = logClassifierPrsJSON;
+      bors = true;
+    };
+
+    cardano-chain = {
+      description = "Cardano Chain";
+      url = "https://github.com/input-output-hk/cardano-chain.git";
+      branch = "master";
+      input = "chain";  # corresponds to argument in cardano-chain/release.nix
+      prs = chainPrsJSON;
+      bors = true;
+    };
+
+    ouroboros-network = {
+      description = "Ouroboros Network";
+      url = "https://github.com/input-output-hk/ouroboros-network.git";
+      branch = "master";
+      prs = ouroborosNetworkPrsJSON;
+      bors = true;
+    };
+
+    cardano-wallet = {
+      description = "Cardano Wallet";
+      url = "https://github.com/input-output-hk/cardano-wallet.git";
+      branch = "develop";
+      prs = walletPrsJSON;
+    };
+  };
+
+  ##########################################################################
+  # Jobset generation functions
+
   mkFetchGithub = value: {
     inherit value;
     type = "git";
     emailresponsible = false;
   };
-  nixpkgs-src = builtins.fromJSON (builtins.readFile ./../nixpkgs-src.json);
-  pkgs = import nixpkgs {};
 
   defaultSettings = {
     enabled = 1;
@@ -57,6 +134,82 @@ let
     schedulingshares = 420;
   };
 
+  # Removes PRs which have any of the labels in ./pr-excluded-labels.nix
+  exclusionFilter = let
+    excludedLabels = import ./pr-excluded-labels.nix;
+    justExcluded = filter (label: (elem label.name excludedLabels));
+    isEmpty = ls: length ls == 0;
+  in
+    filterAttrs (_: prInfo: isEmpty (justExcluded (prInfo.labels or [])));
+
+  loadPrsJSON = path: exclusionFilter (builtins.fromJSON (builtins.readFile path));
+
+  # Make jobset for a project default build
+  mkJobset = { name, description, url, input, branch }: let
+    jobset = defaultSettings // {
+      nixexprpath = "release.nix";
+      nixexprinput = input;
+      inherit description;
+      inputs = {
+        "${input}" = mkFetchGithub "${url} ${branch}";
+      };
+    };
+  in
+    nameValuePair name jobset;
+
+  # Make jobsets for extra project branches (e.g. release branches)
+  mkJobsetBranches = { name, description, url, input }:
+    mapAttrsToList (suffix: branch:
+      mkJobset { name = "${name}-${suffix}"; inherit description url input branch; });
+
+  # Make a jobset for a GitHub PRs
+  mkJobsetPR = { name, description, input, modifier }: num: info: {
+    name = "${name}-pr-${num}";
+    value = defaultSettings // modifier {
+      description = "PR ${num}: ${info.title}";
+      nixexprinput = input;
+      nixexprpath = "release.nix";
+      inputs = {
+        "${input}" = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
+      };
+    };
+  };
+
+  # Load the PRs json and make a jobset for each
+  mkJobsetPRs = { name, description, input, modifier, prs }:
+    mapAttrsToList
+      (mkJobsetPR { inherit name description input modifier; })
+      (loadPrsJSON prs);
+
+  # Add two extra jobsets for the bors staging and trying branches
+  mkJobsetBors = { name, ... }@args: let
+    jobset = branch: (mkJobset (args // { inherit branch; })).value;
+  in [
+    (nameValuePair "${name}-bors-staging" (highPrio (jobset "bors/staging")))
+    (nameValuePair "${name}-bors-trying" (jobset "bors/trying"))
+  ];
+
+  # Make all the jobsets for a project repo, according to the "repos" spec above.
+  mkRepoJobsets = let
+    mkRepo = name: info: let
+      input = info.input or name;
+      branch = info.branch or "master";
+      params = { inherit name input; inherit (info) description url; };
+      prJobsetModifier = info.prJobsetModifier or (s: s);
+    in
+      [ (mkJobset (params // { inherit branch; })) ] ++
+      (mkJobsetBranches params (info.branches or {})) ++
+      (mkJobsetPRs { inherit name input; inherit (info) description prs; modifier = prJobsetModifier; }) ++
+      (optionals (info.bors or false) (mkJobsetBors params));
+  in
+    rs: listToAttrs (concatLists (mapAttrsToList mkRepo rs));
+
+
+  ##########################################################################
+  # iohk-ops structure is slightly different
+
+  iohkOpsURI = "https://github.com/input-output-hk/iohk-ops.git";
+  nixpkgs-src = builtins.fromJSON (builtins.readFile ./../nixpkgs-src.json);
   mkNixops = nixopsBranch: nixpkgsRev: {
     nixexprpath = "jobsets/cardano.nix";
     description = "IOHK-Ops";
@@ -78,173 +231,31 @@ let
       };
     };
   };
-  mkCardano = cardanoBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "cardano";
-    description = "Cardano SL";
-    inputs = {
-      cardano = mkFetchGithub "https://github.com/input-output-hk/cardano-sl.git ${cardanoBranch}";
-    };
-  };
-  makeCardanoPR = num: info: {
-    name = "cardano-sl-pr-${num}";
-    value = defaultSettings // withFasterBuild {
-      description = "PR ${num}: ${info.title}";
-      nixexprinput = "cardano";
-      nixexprpath = "release.nix";
-      inputs = {
-        cardano = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  mkCardanoChain = cardanoBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "chain";
-    description = "Cardano Chain";
-    inputs = {
-      chain = mkFetchGithub "https://github.com/input-output-hk/cardano-chain.git ${cardanoBranch}";
-    };
-  };
-  mkCardanoChainPR = num: info: {
-    name = "cardano-chain-pr-${num}";
-    value = defaultSettings // {
-      nixexprpath = "release.nix";
-      nixexprinput = "chain";
-      description = "Cardano Chain";
-      inputs = {
-        chain = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  mkDaedalus = daedalusBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "daedalus";
-    description = "Daedalus Wallet";
-    inputs = {
-      daedalus = mkFetchGithub "https://github.com/input-output-hk/daedalus.git ${daedalusBranch}";
-    };
-  };
-  mkPlutus = plutusBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "plutus";
-    description = "Plutus Language";
-    inputs = {
-      plutus = mkFetchGithub "https://github.com/input-output-hk/plutus.git ${plutusBranch}";
-    };
-  };
-  mkLogClassifier = logClassifierBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "log-classifier";
-    description = "Log Classifier";
-    inputs = {
-      log-classifier = mkFetchGithub "https://github.com/input-output-hk/log-classifier.git ${logClassifierBranch}";
-    };
-  };
-  mkOuroborosNetwork = ouroborosNetworkBranch: {
-    nixexprpath = "release.nix";
-    nixexprinput = "ouroboros-network";
-    description = "Ouroboros Network";
-    inputs = {
-      ouroboros-network = mkFetchGithub "https://github.com/input-output-hk/ouroboros-network.git ${ouroborosNetworkBranch}";
-    };
-  };
-  makeDaedalusPR = num: info: {
-    name = "daedalus-pr-${num}";
-    value = defaultSettings // {
-      description = "PR ${num}: ${info.title}";
-      nixexprinput = "daedalus";
-      nixexprpath = "release.nix";
-      inputs = {
-        daedalus = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  makePlutusPR = num: info: {
-    name = "plutus-pr-${num}";
-    value = defaultSettings // {
-      description = "PR ${num}: ${info.title}";
-      nixexprinput = "plutus";
-      nixexprpath = "release.nix";
-      inputs = {
-        plutus = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  makeLogClassifierPR = num: info: {
-    name = "log-classifier-pr-${num}";
-    value = defaultSettings // {
-      description = "PR ${num}: ${info.title}";
-      nixexprinput = "log-classifier";
-      nixexprpath = "release.nix";
-      inputs = {
-        log-classifier = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  makeOuroborosNetworkPR = num: info: {
-    name = "ouroboros-network-pr-${num}";
-    value = defaultSettings // {
-      description = "PR ${num}: ${info.title}";
-      nixexprinput = "ouroboros-network";
-      nixexprpath = "release.nix";
-      inputs = {
-        ouroboros-network = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
-      };
-    };
-  };
-  PRExcludedLabels = import ./pr-excluded-labels.nix;
-  exclusionFilter = pkgs.lib.filterAttrs (_: prInfo: builtins.length (builtins.filter (prLabel: (builtins.elem prLabel.name PRExcludedLabels))
-                                                                                      (prInfo.labels or []))
-                                                     == 0);
-  nixopsPrJobsets   = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeNixopsPR   (exclusionFilter nixopsPrs));
-  cardanoPrJobsets  = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeCardanoPR  (exclusionFilter cardanoPrs));
-  daedalusPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeDaedalusPR (exclusionFilter daedalusPrs));
-  plutusPrJobsets   = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makePlutusPR   (exclusionFilter plutusPrs));
-  logClassifierPrJobsets   = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeLogClassifierPR   (exclusionFilter logClassifierPrs));
-  ouroborosNetworkPrJobsets   = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList makeOuroborosNetworkPR   (exclusionFilter ouroborosNetworkPrs));
-  chainPrJobsets = pkgs.lib.listToAttrs (pkgs.lib.mapAttrsToList mkCardanoChainPR (exclusionFilter chainPrs));
-  mainJobsets = with pkgs.lib; mapAttrs (name: settings: defaultSettings // settings) (rec {
-    cardano-sl = mkCardano "develop";
-    cardano-sl-master = mkCardano "master";
-    cardano-sl-1-0 = mkCardano "release/1.0.x";
-    cardano-sl-1-2 = mkCardano "release/1.2.0";
-    cardano-sl-1-3 = mkCardano "release/1.3.1";
-    cardano-sl-2-0 = mkCardano "release/2.0.0";
-    cardano-sl-bors-staging = highPrio (mkCardano "bors/staging");
-    cardano-sl-bors-trying = mkCardano "bors/trying";
+  nixopsPrJobsets = listToAttrs (mapAttrsToList makeNixopsPR (loadPrsJSON nixopsPrsJSON));
 
-    cardano-chain = mkCardanoChain "master";
-    cardano-chain-bors-staging = highPrio (mkCardanoChain "bors/staging");
-    cardano-chain-bors-trying = mkCardanoChain "bors/trying";
+  ##########################################################################
+  # Jobsets which don't fit into the regular structure
 
+  extraJobsets = mapAttrs (name: settings: defaultSettings // settings) ({
     # Provides cached build projects for PR builds with -O0
-    no-opt-cardano-sl = withFasterBuild (mkCardano "develop");
+    no-opt-cardano-sl = withFasterBuild mainJobsets.cardano-sl;
 
-    daedalus = mkDaedalus "develop";
-    daedalus-bors-staging = mkDaedalus "bors/staging";
-    daedalus-bors-trying = mkDaedalus "bors/trying";
-
-    plutus = mkPlutus "master";
-
-    log-classifier = mkLogClassifier "master";
-    log-classifier-bors-staging = highPrio (mkLogClassifier "bors/staging");
-    log-classifier-bors-trying = mkLogClassifier "bors/trying";
-
-    ouroboros-network = mkOuroborosNetwork "master";
-    ouroboros-network-bors-staging = highPrio (mkOuroborosNetwork "bors/staging");
-    ouroboros-network-bors-trying = mkOuroborosNetwork "bors/trying";
-
+    # iohk-ops (this repo)
     iohk-ops = mkNixops "master" nixpkgs-src.rev;
     iohk-ops-bors-staging = highPrio (mkNixops "bors-staging" nixpkgs-src.rev);
     iohk-ops-bors-trying = mkNixops "bors-trying" nixpkgs-src.rev;
-  });
-  jobsetsAttrs = daedalusPrJobsets // nixopsPrJobsets // plutusPrJobsets // logClassifierPrJobsets // ouroborosNetworkPrJobsets // (if handleCardanoPRs then cardanoPrJobsets else {}) // chainPrJobsets // mainJobsets;
-  jobsetJson = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);
+  } // nixopsPrJobsets);
+
+  ##########################################################################
+  # The final jobsets spec as JSON
+
+  mainJobsets = mkRepoJobsets repos;
+  jobsetsAttrs = mainJobsets // extraJobsets;
 in {
-  jobsets = with pkgs.lib; pkgs.runCommand "spec.json" {} ''
+  jobsets = pkgs.runCommand "spec.json" {} ''
     cat <<EOF
     ${builtins.toJSON declInput}
     EOF
-    cp ${jobsetJson} $out
+    cp ${pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs)} $out
   '';
 }

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -11,7 +11,7 @@
     "keepnr": 3,
     "inputs": {
          "src": { "type": "git", "value": "https://github.com/input-output-hk/iohk-ops.git master", "emailresponsible": false }
-         ,"nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs-channels.git nixos-16.09", "emailresponsible": false }
+         ,"nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs-channels.git nixos-18.09", "emailresponsible": false }
          ,"nixopsPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-ops", "emailresponsible": false }
          ,"cardanoPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-sl", "emailresponsible": false }
          ,"daedalusPrsJSON": { "type": "githubpulls", "value": "input-output-hk daedalus", "emailresponsible": false }

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -19,5 +19,6 @@
          ,"logClassifierPrsJSON": { "type": "githubpulls", "value": "input-output-hk log-classifier", "emailresponsible": false }
          ,"ouroborosNetworkPrsJSON": { "type": "githubpulls", "value": "input-output-hk ouroboros-network", "emailresponsible": false }
          ,"chainPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-chain", "emailresponsible": false }
+         ,"walletPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-wallet", "emailresponsible": false }
      }
 }


### PR DESCRIPTION
* Adds jobsets for the cardano-wallet repo.
* The file needed to be cleaned up because there was code duplication for every project.

### Testing steps

Build the jobset spec with example data on the master branch and PR branch, then compare results with a diff program.

    cat $(nix-build jobsets/default.nix --no-out-link) | jq . > spec.json
