### PR TITLE
[DEVOPS-1208] hydra: send github CI status for daedalus-mingw32-pkg

### DIFF
--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -96,6 +96,14 @@ in {
         excludeBuildFromContext = 1
         useShortContext = 1
       </githubstatus>
+      # DEVOPS-1208 This CI status for cardano-sl is needed while the
+      # Daedalus Windows installer is built on AppVeyor or Buildkite
+      <githubstatus>
+        jobs = serokell:cardano-sl.*:daedalus-mingw32-pkg
+        inputs = cardano
+        excludeBuildFromContext = 1
+        useShortContext = 1
+      </githubstatus>
       <githubstatus>
         jobs = serokell:daedalus.*:tests\..*
         inputs = daedalus


### PR DESCRIPTION
Updates the hydra config file.

The CI status will be picked up by the AppVeyor daedalus installers build.