### PR TITLE
infra: Add GitHub deploy keys to buildkite-agent

### DIFF
--- a/modules/buildkite-agent.nix
+++ b/modules/buildkite-agent.nix
@@ -57,6 +57,7 @@ in
       user    = "buildkite-agent";
       permissions = "0770";
     };
+    # SSH keypair for buildkite-agent user
     buildkite-ssh-private = {
       keyFile = ./. + "/../static/buildkite-ssh";
       user    = "buildkite-agent";
@@ -65,6 +66,17 @@ in
       keyFile = ./. + "/../static/buildkite-ssh.pub";
       user    = "buildkite-agent";
     };
+    # GitHub deploy key for input-output-hk/hackage.nix
+    buildkite-hackage-ssh-private = {
+      keyFile = ./. + "/../static/buildkite-hackage-ssh";
+      user    = "buildkite-agent";
+    };
+    # GitHub deploy key for input-output-hk/stackage.nix
+    buildkite-stackage-ssh-private = {
+      keyFile = ./. + "/../static/buildkite-stackage-ssh";
+      user    = "buildkite-agent";
+    };
+    # API Token for BuildKite
     buildkite-token = {
       keyFile = ./. + "/../static/buildkite_token";
       user    = "buildkite-agent";


### PR DESCRIPTION
Needed for input-output-hk/haskell.nix#56.

Before deploying, create these keys on the infra deployer:
```
ssh-keygen -t rsa -f static/buildkite-hackage-ssh -C buildkite-agent@hackage.nix
ssh-keygen -t rsa -f static/buildkite-stackage-ssh -C buildkite-agent@stackage.nix
```

After deploying, add these as deploy keys to the relevant github repos.
