### PR TITLE
Buildkite: fix NIX_PATH and add deployment key for haskell.nix

### DIFF
--- a/modules/buildkite-agent.nix
+++ b/modules/buildkite-agent.nix
@@ -96,6 +96,13 @@ in
       user    = "buildkite-agent";
     };
 
+    # GitHub deploy key for input-output-hk/haskell.nix
+    # (used to update gh-pages documentation)
+    buildkite-haskell-dot-nix-ssh-private = {
+      keyFile = ./. + "/../static/buildkite-haskell-dot-nix-ssh";
+      user    = "buildkite-agent";
+    };
+
     # API Token for BuildKite
     buildkite-token = {
       keyFile = ./. + "/../static/buildkite_token";

--- a/modules/buildkite-agent.nix
+++ b/modules/buildkite-agent.nix
@@ -29,7 +29,12 @@ in
       # Provide a minimal build environment
       export NIX_BUILD_SHELL="/run/current-system/sw/bin/bash"
       export PATH="/run/current-system/sw/bin:$PATH"
-      export NIX_PATH="nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
+
+      # Provide NIX_PATH, unless it's already set by the pipeline
+      if [ -z "$NIX_PATH" ]; then
+          # see iohk-ops/modules/common.nix (system.extraSystemBuilderCmds)
+          export NIX_PATH="nixpkgs=/run/current-system/nixpkgs"
+      fi
 
       # load S3 credentials for artifact upload
       source /var/lib/buildkite-agent/hooks/aws-creds


### PR DESCRIPTION
Fix problems found when doing input-output-hk/haskell.nix#93.