### PR TITLE
[DEVOPS-1252] begin migration to the Cardano project in hydra

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -28,7 +28,7 @@
 , logClassifierPrsJSON ? ./simple-pr-dummy.json
 , ouroborosNetworkPrsJSON ? ./simple-pr-dummy.json
 , iohkMonitoringPrsJSON ? ./simple-pr-dummy.json
-, chainPrsJSON ? ./simple-pr-dummy.json
+, ledgerPrsJSON ? ./simple-pr-dummy.json
 , cardanoLedgerSpecsPrsJSON ? ./simple-pr-dummy.json
 , shellPrsJSON ? ./simple-pr-dummy.json
 , walletPrsJSON ? ./simple-pr-dummy.json
@@ -89,8 +89,7 @@ let
       description = "Cardano Ledger";
       url = "https://github.com/input-output-hk/cardano-ledger.git";
       branch = "master";
-      input = "chain";  # corresponds to argument in cardano-ledger/release.nix
-      prs = chainPrsJSON;
+      prs = ledgerPrsJSON;
       bors = true;
     };
 

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -21,7 +21,7 @@
          ,"logClassifierPrsJSON": { "type": "githubpulls", "value": "input-output-hk log-classifier", "emailresponsible": false }
          ,"ouroborosNetworkPrsJSON": { "type": "githubpulls", "value": "input-output-hk ouroboros-network", "emailresponsible": false }
          ,"iohkMonitoringPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-monitoring-framework", "emailresponsible": false }
-         ,"chainPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-chain", "emailresponsible": false }
+         ,"ledgerPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger", "emailresponsible": false }
          ,"cardanoLedgerSpecsPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger-specs", "emailresponsible": false }
          ,"walletPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-wallet", "emailresponsible": false }
      }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -97,7 +97,7 @@ in {
 
       ${mkStatusBlocks [
         { jobset = "iohk-ops"; inputs = "jobsets"; }
-        { jobset = "cardano-ledger"; inputs = "chain"; }
+        { jobset = "cardano-ledger"; inputs = "cardano-ledger"; }
         { jobset = "cardano-ledger-specs"; inputs = "cardano-ledger-specs"; }
         { jobset = "cardano"; inputs = "cardano"; }
         { jobset = "plutus"; inputs = "plutus"; }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -97,8 +97,8 @@ in {
 
       ${mkStatusBlocks [
         { jobset = "iohk-ops"; inputs = "jobsets"; }
-        { jobset = "cardano-ledger"; inputs = "cardano-ledger"; }
         { jobset = "cardano-ledger-specs"; inputs = "cardano-ledger-specs"; }
+        { jobset = "cardano-ledger"; inputs = "cardano-ledger"; }
         { jobset = "cardano"; inputs = "cardano"; }
         { jobset = "plutus"; inputs = "plutus"; }
         { jobset = "log-classifier"; inputs = "log-classifier"; }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -25,6 +25,21 @@ let
       ip1 = if nodes.${host}.options.networking.publicIPv4.isDefined then nodes.${host}.config.networking.publicIPv4 else "0.0.0.0";
     in
       if ip1 == null then "0.0.0.0" else ip1;
+  mkGithubStatus = { jobset, inputs }: ''
+    <githubstatus>
+      jobs = Cardano:${jobset}.*:required
+      inputs = ${inputs}
+      excludeBuildFromContext = 1
+      useShortContext = 1
+    </githubstatus>
+    <githubstatus>
+      jobs = serokell:${jobset}.*:required
+      inputs = ${inputs}
+      excludeBuildFromContext = 1
+      useShortContext = 1
+    </githubstatus>
+  '';
+  mkStatusBlocks = concatMapStringsSep "" mkGithubStatus;
 in {
   imports = [ ./github-webhook-util.nix ];
   environment.etc = lib.singleton {
@@ -79,30 +94,19 @@ in {
       <github_authorization>
         input-output-hk = ${builtins.readFile ../static/github_token}
       </github_authorization>
-      <githubstatus>
-        jobs = serokell:iohk-ops.*:required
-        inputs = jobsets
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = Cardano:cardano-ledger.*:required
-        inputs = chain
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = Cardano:cardano-ledger-specs.*:required
-        inputs = cardano-ledger-specs
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = serokell:cardano.*:required
-        inputs = cardano
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
+
+      ${mkStatusBlocks [
+        { jobset = "iohk-ops"; inputs = "jobsets"; }
+        { jobset = "cardano-ledger"; inputs = "chain"; }
+        { jobset = "cardano-ledger-specs"; inputs = "cardano-ledger-specs"; }
+        { jobset = "cardano"; inputs = "cardano"; }
+        { jobset = "plutus"; inputs = "plutus"; }
+        { jobset = "log-classifier"; inputs = "log-classifier"; }
+        { jobset = "ouroboros-network"; inputs = "ouroboros-network"; }
+        { jobset = "iohk-monitoring"; inputs = "iohk-monitoring"; }
+        { jobset = "haskell-nix"; inputs = "haskell-nix"; }
+      ]}
+
       # DEVOPS-1208 This CI status for cardano-sl is needed while the
       # Daedalus Windows installer is built on AppVeyor or Buildkite
       <githubstatus>
@@ -114,36 +118,6 @@ in {
       <githubstatus>
         jobs = serokell:daedalus.*:tests\..*
         inputs = daedalus
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = serokell:plutus.*:required
-        inputs = plutus
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = serokell:log-classifier.*:required
-        inputs = log-classifier
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = serokell:ouroboros-network.*:required
-        inputs = ouroboros-network
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = Cardano:iohk-monitoring.*:required
-        inputs = iohk-monitoring
-        excludeBuildFromContext = 1
-        useShortContext = 1
-      </githubstatus>
-      <githubstatus>
-        jobs = Cardano:haskell-nix.*:required
-        inputs = haskell-nix
         excludeBuildFromContext = 1
         useShortContext = 1
       </githubstatus>


### PR DESCRIPTION
this initial PR configures hydra to report the `required` job on both the `Cardano` and `serokell` project

that will allow smoothly transitioning the required CI checks in each repo over