### PR TITLE
modules/cardano-explorer:  t2.large -> t3.xlarge (2x RAM, newer system)

### DIFF
--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -10,6 +10,8 @@ in
   imports = [ ./cardano.nix ];
   global.dnsHostname   = mkForce   "cardano-explorer";
 
+  deployment.ec2.instanceType = "t3.xlarge";
+
   services.cardano-node.executable = "${explorer-drv}/bin/cardano-explorer";
 
   networking.firewall.allowedTCPPorts = [


### PR DESCRIPTION
This is a sweeping change that affects Explorer deployment on all environments.
