### PR TITLE
Buildkite: Fix environment hook evaluation

### DIFF
--- a/modules/buildkite-agent.nix
+++ b/modules/buildkite-agent.nix
@@ -31,7 +31,7 @@ in
       export PATH="/run/current-system/sw/bin:$PATH"
 
       # Provide NIX_PATH, unless it's already set by the pipeline
-      if [ -z "$NIX_PATH" ]; then
+      if [ -z "''${NIX_PATH:-}" ]; then
           # see iohk-ops/modules/common.nix (system.extraSystemBuilderCmds)
           export NIX_PATH="nixpkgs=/run/current-system/nixpkgs"
       fi


### PR DESCRIPTION
It's failing with:

    /nix/store/v61l5n40ivddx5p0xza87wyn92fgjwz2-buildkite-agent-hooks/environment: line 8: NIX_PATH: unbound variable
