### PR TITLE
fix the hydra eval

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -165,7 +165,7 @@ let
     schedulingshares = 42;
     checkinterval = 60;
     inputs = {
-      nixpkgs = mkFetchGithub "https://github.com/NixOS/nixpkgs.git ${nixpkgs-src.rev}";
+      nixpkgs = mkFetchGithub "https://github.com/input-output-hk/nixpkgs.git ${nixpkgs-src.rev}";
       jobsets = mkFetchGithub "${iohkOpsURI} master";
     };
     enableemail = false;
@@ -264,7 +264,7 @@ let
     nixexprpath = "jobsets/cardano.nix";
     description = "IOHK-Ops";
     inputs = {
-      nixpkgs = mkFetchGithub "https://github.com/NixOS/nixpkgs.git ${nixpkgsRev}";
+      nixpkgs = mkFetchGithub "https://github.com/input-output-hk/nixpkgs.git ${nixpkgsRev}";
       jobsets = mkFetchGithub "${iohkOpsURI} ${nixopsBranch}";
       nixops = mkFetchGithub "https://github.com/NixOS/NixOps.git tags/v1.5";
     };
@@ -275,7 +275,7 @@ let
       description = "PR ${num}: ${info.title}";
       nixexprpath = "jobsets/cardano.nix";
       inputs = {
-        nixpkgs = mkFetchGithub "https://github.com/NixOS/nixpkgs.git ${nixpkgs-src.rev}";
+        nixpkgs = mkFetchGithub "https://github.com/input-output-hk/nixpkgs.git ${nixpkgs-src.rev}";
         jobsets = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
         nixops = mkFetchGithub "https://github.com/NixOS/NixOps.git tags/v1.5";
       };


### PR DESCRIPTION
the new nixpkgs-src.json refers to a git commit that does not exist upstream

this results in hydra failing to fetch the specified commit from upstream when supplying <nixpkgs> to all jobsets