### PR TITLE
packet.nix machine fix for manual being renamed

### DIFF
--- a/deployments/packet-net.nix
+++ b/deployments/packet-net.nix
@@ -22,8 +22,6 @@ let
       };
       groups.staging = {};
     };
-    ## Disabled due to build failures:
-    documentation.nixos.enable = false;
     # services.extra-statsd = mkForce false;
   } // extraopts;
 in


### PR DESCRIPTION
This was a change required to redeploy buildkite to update an API token in a hook.