### PR TITLE
Avoid reference on globals from monitoring-exporters.nix

### DIFF
--- a/modules/devops.nix
+++ b/modules/devops.nix
@@ -14,6 +14,8 @@ with import ./../lib.nix;
 
       # DEVOPS-64: disable log bursting
       journald.rateLimitBurst    = 0;
+
+      monitoring-exporters.graylogHost = "${config.deployment.arguments.globals.monitoringNV.name}-ip:5044";
     };
 
   };

--- a/modules/monitoring-exporters.nix
+++ b/modules/monitoring-exporters.nix
@@ -4,8 +4,6 @@ with lib;
 
 let
   cfg = config.services.monitoring-exporters;
-  monitoring = config.deployment.arguments.globals.monitoringNV;
-
 in {
 
   options = {
@@ -20,7 +18,7 @@ in {
 
       graylogHost = mkOption {
         type = types.nullOr types.str;
-        default = "${monitoring.name}-ip:5044";
+        default = null;
         example = "graylog:5044";
         description = ''
           The host port under which Graylog is externally reachable.

--- a/modules/production.nix
+++ b/modules/production.nix
@@ -14,6 +14,8 @@ with import ../lib.nix;
 
       # DEVOPS-64: disable log bursting
       journald.rateLimitBurst    = 0;
+
+      monitoring-exporters.graylogHost = "${config.deployment.arguments.globals.monitoringNV.name}-ip:5044";
     };
 
   };

--- a/modules/staging.nix
+++ b/modules/staging.nix
@@ -14,6 +14,8 @@ with import ./../lib.nix;
 
       # DEVOPS-64: disable log bursting
       journald.rateLimitBurst    = 0;
+
+      monitoring-exporters.graylogHost = "${config.deployment.arguments.globals.monitoringNV.name}-ip:5044";
     };
 
   };

--- a/modules/testnet.nix
+++ b/modules/testnet.nix
@@ -14,6 +14,8 @@ with import ./../lib.nix;
 
       # DEVOPS-64: disable log bursting
       journald.rateLimitBurst    = 0;
+
+      monitoring-exporters.graylogHost = "${config.deployment.arguments.globals.monitoringNV.name}-ip:5044";
     };
 
   };


### PR DESCRIPTION
 so that it can be used outside cardano specific deployments.