### PR TITLE
deployer-base: Making packages and users overridable.

### DIFF
--- a/modules/deployer-base.nix
+++ b/modules/deployer-base.nix
@@ -17,27 +17,29 @@ in
   security.sudo.enable = true;
   security.sudo.wheelNeedsPassword = false;
 
-  environment.systemPackages = (with iohk-pkgs; [
-    iohk-ops
-    terraform
-    mfa
-  ]) ++ (with pkgs; [
-    psmisc
-    gnupg
-    nixops
-    awscli
-    jq
-    yq
-    python3
-    htop
-  ]);
+  environment = mkDefault {
+    systemPackages = (with iohk-pkgs; [
+        iohk-ops
+        terraform
+        mfa
+      ]) ++ (with pkgs; [
+        psmisc
+        gnupg
+        nixops
+        awscli
+        jq
+        yq
+        python3
+        htop
+      ]);
+  };
 
   users.groups.deployers = {};
 
   users.users = {
     # Re-deploy the deployer host itself,
     # and apply global terraform.
-    deployer = {
+    deployer = mkDefault {
       isNormalUser = true;
       description  = "Deploy the deployer";
       group        = "deployers";


### PR DESCRIPTION
We need to override both the packages and the users installed on a downstream deployer.