### PR TITLE
Restruct mon creds, add svr sizing customization

### DIFF
--- a/deployments/monitoring-env-production.nix
+++ b/deployments/monitoring-env-production.nix
@@ -1,5 +1,45 @@
 {
   require = [ ./monitoring.nix ];
-  monitoring = import ../modules/production.nix;
-}
+  monitoring = { pkgs, lib, ... }:
+  {
+    imports = [
+      ../modules/production.nix
+    ];
 
+    deployment.ec2.instanceType = "t3.xlarge";
+    boot.loader.grub.device = lib.mkForce "/dev/nvme0n1"; # t3.xlarge has an nvme disk, and amazon-image.nix isnt handling it right yet
+    deployment.ec2.ebsInitialRootDiskSize = 1000;
+
+    systemd.services.graylog.environment = { JAVA_OPTS = ''
+      -Djava.library.path=${pkgs.graylog}/lib/sigar -Xms3g -Xmx3g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow
+    ''; };
+    services.elasticsearch.extraJavaOptions = [ "-Xms6g" "-Xmx6g" ];
+    services.monitoring-services.applicationDashboards = ../modules/grafana/cardano;
+    services.monitoring-services.applicationRules = [
+      {
+        alert = "chain_quality_degraded";
+        expr = "cardano_chain_quality_last_k__2160__blocks__ < 99";
+        for = "5m";
+        labels = {
+          severity = "page";
+        };
+        annotations = {
+          summary = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks.";
+          description = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks (<99%).";
+        };
+      }
+      {
+        alert = "mempoolsize_tx_count_too_large";
+        expr = "max_over_time(cardano_MemPoolSize[5m]) > 190";
+        for = "1m";
+        labels = {
+          severity = "page";
+        };
+        annotations = {
+          summary = "{{$labels.alias}}: MemPoolSize tx count is larger than expected.";
+          description = "{{$labels.alias}}: When a node's MemPoolSize grows larger than the system can handle, transactions will be dropped. The actual thresholds for that in mainnet are unknown, but [based on benchmarks done beforehand](https://input-output-rnd.slack.com/archives/C2VJ41WDP/p1506563332000201) transactions started getting dropped when the MemPoolSize was ~200 txs.";
+        };
+      }
+    ];
+  };
+}

--- a/deployments/monitoring-env-staging.nix
+++ b/deployments/monitoring-env-staging.nix
@@ -1,10 +1,19 @@
 {
   require = [ ./monitoring.nix ];
-  monitoring = { ... }:
+  monitoring = { pkgs, lib, ... }:
   {
     imports = [
       ../modules/staging.nix
     ];
+
+    deployment.ec2.instanceType = "t3.xlarge";
+    boot.loader.grub.device = lib.mkForce "/dev/nvme0n1"; # t3.xlarge has an nvme disk, and amazon-image.nix isnt handling it right yet
+    deployment.ec2.ebsInitialRootDiskSize = 1000;
+
+    systemd.services.graylog.environment = { JAVA_OPTS = ''
+      -Djava.library.path=${pkgs.graylog}/lib/sigar -Xms3g -Xmx3g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow
+    ''; };
+    services.elasticsearch.extraJavaOptions = [ "-Xms6g" "-Xmx6g" ];
     services.monitoring-services.applicationDashboards = ../modules/grafana/cardano;
     services.monitoring-services.applicationRules = [
       {

--- a/deployments/monitoring-env-testnet.nix
+++ b/deployments/monitoring-env-testnet.nix
@@ -1,4 +1,45 @@
 {
   require = [ ./monitoring.nix ];
-  monitoring = import ../modules/testnet.nix;
+  monitoring = { pkgs, lib, ... }:
+  {
+    imports = [
+      ../modules/testnet.nix
+    ];
+
+    deployment.ec2.instanceType = "t3.xlarge";
+    boot.loader.grub.device = lib.mkForce "/dev/nvme0n1"; # t3.xlarge has an nvme disk, and amazon-image.nix isnt handling it right yet
+    deployment.ec2.ebsInitialRootDiskSize = 1000;
+
+    systemd.services.graylog.environment = { JAVA_OPTS = ''
+      -Djava.library.path=${pkgs.graylog}/lib/sigar -Xms3g -Xmx3g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow
+    ''; };
+    services.elasticsearch.extraJavaOptions = [ "-Xms6g" "-Xmx6g" ];
+    services.monitoring-services.applicationDashboards = ../modules/grafana/cardano;
+    services.monitoring-services.applicationRules = [
+      {
+        alert = "chain_quality_degraded";
+        expr = "cardano_chain_quality_last_k__2160__blocks__ < 99";
+        for = "5m";
+        labels = {
+          severity = "page";
+        };
+        annotations = {
+          summary = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks.";
+          description = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks (<99%).";
+        };
+      }
+      {
+        alert = "mempoolsize_tx_count_too_large";
+        expr = "max_over_time(cardano_MemPoolSize[5m]) > 190";
+        for = "1m";
+        labels = {
+          severity = "page";
+        };
+        annotations = {
+          summary = "{{$labels.alias}}: MemPoolSize tx count is larger than expected.";
+          description = "{{$labels.alias}}: When a node's MemPoolSize grows larger than the system can handle, transactions will be dropped. The actual thresholds for that in mainnet are unknown, but [based on benchmarks done beforehand](https://input-output-rnd.slack.com/archives/C2VJ41WDP/p1506563332000201) transactions started getting dropped when the MemPoolSize was ~200 txs.";
+        };
+      }
+    ];
+  };
 }

--- a/deployments/monitoring.nix
+++ b/deployments/monitoring.nix
@@ -40,18 +40,9 @@ in
       } // (import ../static/oauth.nix);
 
 
-      # Change the Grafana root default username and password for your deployment
-      # NOTE: These two Grafana settings only take effect on the initial deployment.
-      #
-      grafanaRootUsername = "changeme";
-      grafanaRootPassword = "changeme";
-
-
-      # Change the Graylog root default username and password for your deployment
-      #
-      graylogRootUsername = "changeme";
-      graylogRootPassword = "changeme";
-
+      # NOTE: The Grafana user and password settings only take effect on the initial deployment.
+      grafanaCreds = makeCreds "grafana" { user = "changeme"; password = "changeme"; };
+      graylogCreds = makeCreds "graylog" { user = "changeme"; password = "changeme"; };
 
       monitoredNodes = map (h: h.name) (lib.filter (h: !h.withNginx) hostList);
       nginxMonitoredNodes = map (h: h.name) (lib.filter (h: h.withNginx) hostList);

--- a/lib.nix
+++ b/lib.nix
@@ -108,6 +108,12 @@ in lib // (rec {
   inherit iohkNix iohkNixGoguen goguenNixpkgs;
   inherit fetchPinAuto fetchGitWithSubmodules readPin;
 
+  makeCreds = service: default:
+    if
+      (builtins.pathExists (./static + "/${service}-creds.nix"))
+    then (import (./static + "/${service}-creds.nix"))
+    else default;
+
   ## nodeElasticIP :: Node -> EIP
   nodeElasticIP = node:
     { name = "${node.name}-ip";

--- a/modules/graylog/graylogPreload.sh
+++ b/modules/graylog/graylogPreload.sh
@@ -15,8 +15,8 @@ cpComment="monitorContentPack"         # Must remain set to "monitorContentPack"
 cpVendor="IOHK"                        # Must remain set to "IOHK" for proper script logic
 
 # Curl Definitions
-user="@graylogRootUsername@"
-password="@graylogRootPassword@"
+user="@user@"
+password="@password@"
 graylogApiUrl="http://localhost:9000/api"
 curlH="curl -s -w \"\\\\napiRc: %{http_code}\" -u $user:$password -H 'X-Requested-By: $user' $graylogApiUrl"
 jsonH="-H 'Content-Type: application/json'"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -59,11 +59,13 @@ touch static/github_token{,_mantis_hydra}
 touch static/id_buildfarm{,2} static/id_buildfarm{,2}.pub
 touch static/datadog-api.secret static/datadog-application.secret
 
-test -f static/graylog-cluster-secret ||
-       { echo -n "1234567890123456789012345678901234567890123456789012345678901234" > static/graylog-cluster-secret; }
-
-test -f static/graylog-root-secret ||
-       { echo -n "1234567890123456789012345678901234567890123456789012345678901234" > static/graylog-root-secret; }
+test -f static/graylog-creds.nix ||
+        { echo "{
+  user = \"changeme\";
+  password = \"changeme\";
+  passwordHash = \"1234567890123456789012345678901234567890123456789012345678901234\";
+  clusterSecret = \"1234567890123456789012345678901234567890123456789012345678901234\";
+}" > static/graylog-creds.nix; }
 
 test -f static/tarsnap-cardano-deployer.secret ||
         { echo "secret" > static/tarsnap-cardano-deployer.secret; }


### PR DESCRIPTION
This commit cleans up the graylog and grafana static credentials,
making use of a new iohk-ops lib.nix function `makeCreds`.
Customizations for the monitoring server size in the testnet,
staging and production environments for larger EBS gp2 vols,
EC2 server type and boot loader block device type are added.