### PR TITLE
Fix not being able to disable graylog

### DIFF
--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -754,7 +754,7 @@ in {
             inherit graylogRootPassword;
           })
         );
-      in {
+      in lib.mkIf config.services.graylog.enable {
         description = "Graylog Content Pack Preload Service";
         wantedBy = [ "multi-user.target" ];
         after = [ "graylog.service elasticsearch.service mongodb.service" ];


### PR DESCRIPTION
due to the systemd services `graylog-preload` being defined regardless of whether graylog is enabled or not (... which causes it to fail, crash and burn). I need to be able to deploy without graylog simply because graylog is currently out of scope for the PR I'm trying to merge (and I require some changes that were committed on top of the graylog changes).