### PR TITLE
gac: split `deployments/configurator.nix`

### DIFF
--- a/deployments/configurator.nix
+++ b/deployments/configurator.nix
@@ -1,41 +1,6 @@
-{ accessKeyId
-, deployerIP
-, config
-, ...
-}:
-with (import <nixpkgs> {}).lib;
-{
-  ## Per-machine defaults:
-  defaults = {
-    # For Nixops configs, the `config` object we constructed in `/config.nix` should be sufficient;
-    # for NixOS configs however, we need to make a distinction between defaults and and user-supplied parameters.
-    imports = [ <module/configurator.nix> ];
-
-    # The configurator *module* basically just changes the precedence of everything in `optionDefaults` and `userConfig` and merges them
-    # together. The reason we have to send it off to a NixOS module is because we literally can't do it here in nixops. Trust, I tried. There be dragons and hydrae 🐉🐲.
-    configurator = {
-      # So yeah `config` already has both defaults and user-defined parameters but we can't tell which is which
-      optionDefaults = config;
-      # So we also pass the bare user config so that we can work the magic of set theory (I think?)
-      userConfig     = import <config>;
-    };
-  };
-
-  ## Universal resource logic:
-  resources.ec2KeyPairs."cardano-keypair-${config.node.org}-${config.node.region}" = {
-    inherit accessKeyId; inherit (config.node) region;
-  };
-
-  resources.ec2SecurityGroups = {
-    "allow-deployer-ssh-${config.node.region}-${config.node.org}" = {
-      _file = ./configurator.nix;
-      inherit accessKeyId; inherit (config.node) region;
-      description = "SSH";
-      rules = [{
-        protocol = "tcp"; # TCP
-        fromPort = 22; toPort = 22;
-        sourceIp = deployerIP + "/32";
-      }];
-    };
-  };
+builtins.trace "[WARN] deployments/configurator.nix has been split into deployments/gac/configurator.nix and deployments/gac/common-aws.nix please update your symlinks" {
+  require = [
+    ./gac/configurator.nix
+    ./gac/common-aws.nix
+  ];
 }

--- a/deployments/gac/common-aws.nix
+++ b/deployments/gac/common-aws.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+
+{
+  ## Universal resource logic:
+  resources.ec2KeyPairs."cardano-keypair-${config.node.org}-${config.node.region}" = {
+    inherit (config.node) region accessKeyId;
+  };
+
+  resources.ec2SecurityGroups = {
+    "allow-deployer-ssh-${config.node.region}-${config.node.org}" = {
+      _file = ./configurator.nix;
+      inherit (config.node) region accessKeyId;
+      description = "SSH";
+      rules = [{
+        protocol = "tcp"; # TCP
+        fromPort = 22; toPort = 22;
+        sourceIp = config.cluster.deployerIP + "/32";
+      }];
+    };
+  };
+}

--- a/deployments/gac/configurator.nix
+++ b/deployments/gac/configurator.nix
@@ -1,0 +1,19 @@
+{ config , ...  }:
+
+{
+  ## Per-machine defaults:
+  defaults = {
+    # For Nixops configs, the `config` object we constructed in `/config.nix` should be sufficient;
+    # for NixOS configs however, we need to make a distinction between defaults and and user-supplied parameters.
+    imports = [ <module/configurator.nix> ];
+
+    # The configurator *module* basically just changes the precedence of everything in `optionDefaults` and `userConfig` and merges them
+    # together. The reason we have to send it off to a NixOS module is because we literally can't do it here in nixops. Trust, I tried. There be dragons and hydrae 🐉🐲.
+    configurator = {
+      # So yeah `config` already has both defaults and user-defined parameters but we can't tell which is which
+      optionDefaults = config;
+      # So we also pass the bare user config so that we can work the magic of set theory (I think?)
+      userConfig     = import <config>;
+    };
+  };
+}


### PR DESCRIPTION
into `deployments/gac/{configurator,common-aws}.nix`.

To maintain backward-compatibility I put a placeholder in the original
path (`deployments/configurator.nix`) that `require`s the two new files
and emits a deprecation warning.

This is generally needed for supporting providers other than AWS.

Fixes #599