### PR TITLE
Monitoring improvements

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "24dcb24967cb97293f29ec886b0467be67edbcce",
-  "sha256": "1dw51f9iwq8ja7wap2b8pas4bqpkgr6mwfc20zc7183nc1bb1wf1",
-  "fetchSubmodules": false
+  "rev": "57a0d236eed59c48214ee70128549d6cfdbc73db",
+  "sha256": "04mj27kgwfs6wqqqcypxc17d2r17d193pqi9gv5s7dkrkcz0fqpb",
+  "fetchSubmodules": "false"
 }

--- a/deployments/infrastructure-env-production.nix
+++ b/deployments/infrastructure-env-production.nix
@@ -194,7 +194,9 @@ in {
               name = "exchange-down";
               pagerduty_configs = [
                 {
-                  service_key = (import ../static/pager-duty.nix).exchangeKey;
+                  service_key = if (builtins.pathExists ../static/pager-duty.nix)
+                    then ((import ../static/pager-duty.nix).exchangeKey)
+                    else { exchangeKey = null; };
                 }
               ];
             }

--- a/deployments/monitoring-aws.nix
+++ b/deployments/monitoring-aws.nix
@@ -28,15 +28,15 @@ in {
       };
     };
   };
-  monitoring = { lib, resources, ... }: {
+  monitoring = { config, lib, resources, ... }: {
     deployment = {
       route53.accessKeyId = lib.mkForce IOHKroute53accessKeyId;
       ec2 = {
-        securityGroups = [
+        securityGroups = (optionals (! config.global.omitDetailedSecurityGroups) [
           resources.ec2SecurityGroups."allow-wireguard-in-${region}-${org}"
           resources.ec2SecurityGroups."allow-monitoring-static-peers-${region}-${org}"
           resources.ec2SecurityGroups."allow-public-www-https-${region}-${org}"
-        ];
+        ]);
         region         = mkForce monitoring.region;
         accessKeyId    = monitoring.accessKeyId;
         keyPair        = resources.ec2KeyPairs.${monitoring.keyPairName};

--- a/deployments/monitoring.nix
+++ b/deployments/monitoring.nix
@@ -73,7 +73,9 @@ in
       pagerDuty = {
         inherit (import ../static/pager-duty.nix) serviceKey;
       };
-      deadMansSnitch = import ../static/dead-mans-snitch.nix;
+      deadMansSnitch = if (builtins.pathExists ../static/dead-mans-snitch.nix)
+        then (import ../static/dead-mans-snitch.nix)
+        else { pingUrl = null; };
     };
   };
 }

--- a/deployments/monitoring.nix
+++ b/deployments/monitoring.nix
@@ -70,9 +70,9 @@ in
       monitoredNodes = map (h: h.name) (lib.filter (h: !h.withNginx) hostList);
       nginxMonitoredNodes = map (h: h.name) (lib.filter (h: h.withNginx) hostList);
       webhost = hostName;
-      pagerDuty = {
-        inherit (import ../static/pager-duty.nix) serviceKey;
-      };
+      pagerDuty = if (builtins.pathExists ../static/pager-duty.nix)
+              then { inherit (import ../static/pager-duty.nix) serviceKey; }
+                      else { serviceKey = null; };
       deadMansSnitch = if (builtins.pathExists ../static/dead-mans-snitch.nix)
         then (import ../static/dead-mans-snitch.nix)
         else { pingUrl = null; };

--- a/iohk/iohk-ops.hs
+++ b/iohk/iohk-ops.hs
@@ -187,7 +187,7 @@ centralCommandParser =
                 (SetRev
                  <$> parserProject
                  <*> parserCommit "Commit to set PROJECT's version to"
-                 <*> flag DoCommit DontCommit (long "dont-commit" <> short 'n' <> help "Don't commit the *-src.json"))
+                 <*> flag DontCommit DoCommit (long "do-commit" <> short 'c' <> help "Do commit the *-src.json"))
                 (progDesc "Set commit of PROJECT dependency to COMMIT, and commit the resulting changes"))
              ])
   <|> subparser (mconcat

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -250,7 +250,7 @@ in {
         type = types.nullOr types.str;
         default = null;
         description = ''
-          The seed string for secure cookies. FIXME
+          The pagerDuty service key.
         '';
       };
 


### PR DESCRIPTION
- Remove security group redundancy in development clusters
- Disable deadmansnitch silently upon no static creds key (by setting pingUrl = null)
- Disable pagerduty silently upon no static creds file (by setting to a key of null)
- Bump cardano-sl pin to 3.0.1 tag
- Change io set-rev behavior to no commit by default