### PR TITLE
Fix infinite recursion

### DIFF
--- a/modules/monitoring-exporters.nix
+++ b/modules/monitoring-exporters.nix
@@ -68,11 +68,13 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-
-    (mkIf (config.services.nginx.enable && cfg.metrics) {
+    {
       nixpkgs.overlays = [
         (import ../overlays/monitoring-exporters.nix)
       ];
+    }
+
+    (mkIf (config.services.nginx.enable && cfg.metrics) {
       services.nginx = {
         appendHttpConfig = ''
           vhost_traffic_status_zone;

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -130,7 +130,6 @@ in {
 
       grafanaCreds = mkOption {
         type = types.attrs;
-        default = null;
         description = ''
           An attribute set containing the username and password of the
           default administative user in grafana.  This attribute set
@@ -158,7 +157,6 @@ in {
 
       graylogCreds = mkOption {
         type = types.attrs;
-        default = null;
         description = ''
           An attribute set containing the username, password and
           SHA256 password hash of the default administative user


### PR DESCRIPTION
Upstream changes to `iohk-ops` have introduced an infinite recursion in `gac`-based deployments. This fixes it.

Kudos to @cleverca22 for the intense bisect session and to @johnalotoski for the moral support!