### PR TITLE
Fix gac-new when used in overlay mode

### DIFF
--- a/gac-new.sh
+++ b/gac-new.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Make sure that we are using `find`/`xargs` from GNU and not the (gasp) BSD version 😒
-PATH=$(nix-build -E "(import ./. {}).pkgs.findutils" --no-out-link)/bin:$PATH
+PATH=$(nix-build -E "(import ${gacroot:?} {}).pkgs.findutils" --no-out-link)/bin:$PATH
 
 case "$1" in
 -h | --help | help )


### PR DESCRIPTION
`gac new` is currently failing when used from within an overlay. 

We are now explicitly referring to the `iohk-ops` root directory.