### PR TITLE
Monitoring improvements

### DIFF
--- a/deployments/bors-ng.nix
+++ b/deployments/bors-ng.nix
@@ -32,7 +32,7 @@
       log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-      access_log /var/spool/nginx/logs/access.log x-fwd;
+      access_log syslog:server=unix:/dev/log x-fwd;
     '';
     recommendedGzipSettings = true;
     recommendedOptimisation = true;

--- a/deployments/bors-ng.nix
+++ b/deployments/bors-ng.nix
@@ -28,6 +28,12 @@
 
   services.nginx = {
     enable = true;
+    commonHttpConfig = ''
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log /var/spool/nginx/logs/access.log x-fwd;
+    '';
     recommendedGzipSettings = true;
     recommendedOptimisation = true;
     recommendedProxySettings = true;
@@ -44,4 +50,5 @@
   };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
+  environment.systemPackages = with pkgs; [ goaccess ];
 }

--- a/deployments/monitoring-env-testnet.nix
+++ b/deployments/monitoring-env-testnet.nix
@@ -1,9 +1,12 @@
 {
-  require = [ ./monitoring.nix ];
+  require = [
+    ./monitoring.nix
+  ];
   monitoring = { pkgs, lib, ... }:
   {
     imports = [
       ../modules/testnet.nix
+      ../modules/monitoring-rules-cardano.nix
     ];
 
     deployment.ec2.instanceType = "t3.xlarge";
@@ -14,33 +17,8 @@
       -Djava.library.path=${pkgs.graylog}/lib/sigar -Xms3g -Xmx3g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow
     ''; };
     services.elasticsearch.extraJavaOptions = [ "-Xms6g" "-Xmx6g" ];
+
     services.monitoring-services.grafanaAutoLogin = true;
     services.monitoring-services.applicationDashboards = ../modules/grafana/cardano;
-    services.monitoring-services.applicationRules = [
-      {
-        alert = "chain_quality_degraded";
-        expr = "cardano_chain_quality_last_k__2160__blocks__ < 99";
-        for = "5m";
-        labels = {
-          severity = "page";
-        };
-        annotations = {
-          summary = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks.";
-          description = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks (<99%).";
-        };
-      }
-      {
-        alert = "mempoolsize_tx_count_too_large";
-        expr = "max_over_time(cardano_MemPoolSize[5m]) > 190";
-        for = "1m";
-        labels = {
-          severity = "page";
-        };
-        annotations = {
-          summary = "{{$labels.alias}}: MemPoolSize tx count is larger than expected.";
-          description = "{{$labels.alias}}: When a node's MemPoolSize grows larger than the system can handle, transactions will be dropped. The actual thresholds for that in mainnet are unknown, but [based on benchmarks done beforehand](https://input-output-rnd.slack.com/archives/C2VJ41WDP/p1506563332000201) transactions started getting dropped when the MemPoolSize was ~200 txs.";
-        };
-      }
-    ];
   };
 }

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -17,6 +17,8 @@ in
   ];
   environment.systemPackages = with pkgs; [ goaccess ];
 
+  systemd.services.cardano-node.serviceConfig.LimitNOFILE = 4096;
+
   services.nginx = {
     enable = true;
     commonHttpConfig = ''

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -15,8 +15,16 @@ in
   networking.firewall.allowedTCPPorts = [
     80 443 # nginx
   ];
+  environment.systemPackages = with pkgs; [ goaccess ];
+
   services.nginx = {
     enable = true;
+    commonHttpConfig = ''
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log /var/spool/nginx/logs/access.log x-fwd;
+    '';
     virtualHosts =
      let vhostDomainName = if config.global.dnsDomainname != null
                            then config.global.dnsDomainname else "iohkdev.io";

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -25,7 +25,7 @@ in
       log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-      access_log /var/spool/nginx/logs/access.log x-fwd;
+      access_log syslog:server=unix:/dev/log x-fwd;
     '';
     virtualHosts =
      let vhostDomainName = if config.global.dnsDomainname != null

--- a/modules/cardano-faucet.nix
+++ b/modules/cardano-faucet.nix
@@ -45,7 +45,7 @@ in {
       log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-      access_log /var/spool/nginx/logs/access.log x-fwd;
+      access_log syslog:server=unix:/dev/log x-fwd;
     '';
     virtualHosts = let
       vhostDomainName = if config.global.dnsDomainname != null

--- a/modules/cardano-faucet.nix
+++ b/modules/cardano-faucet.nix
@@ -37,9 +37,16 @@ in {
   };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
+  environment.systemPackages = with pkgs; [ goaccess ];
 
   services.nginx = {
     enable = true;
+    commonHttpConfig = ''
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log /var/spool/nginx/logs/access.log x-fwd;
+    '';
     virtualHosts = let
       vhostDomainName = if config.global.dnsDomainname != null
         then config.global.dnsDomainname else "iohkdev.io";

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -194,7 +194,7 @@ in {
       log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-      access_log /var/spool/nginx/logs/access.log x-fwd;
+      access_log syslog:server=unix:/dev/log x-fwd;
     '';
   };
 }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -160,6 +160,7 @@ in {
   };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
+  environment.systemPackages = with pkgs; [ goaccess ];
   services.nginx = {
     virtualHosts = {
       "hydra.iohk.io" = {
@@ -190,6 +191,10 @@ in {
       gzip_min_length 1000;
       gzip_proxied    expired no-cache no-store private auth;
       gzip_types      text/plain application/xml application/javascript application/x-javascript text/javascript text/xml text/css;
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log /var/spool/nginx/logs/access.log x-fwd;
     '';
   };
 }

--- a/modules/hydra-master-mantis.nix
+++ b/modules/hydra-master-mantis.nix
@@ -67,6 +67,7 @@ in {
     '';
   };
 
+  environment.systemPackages = with pkgs; [ goaccess ];
   services.nginx = {
     virtualHosts = {
       "${hydraDnsName}" = {
@@ -88,6 +89,10 @@ in {
       gzip_min_length 1000;
       gzip_proxied    expired no-cache no-store private auth;
       gzip_types      text/plain application/xml application/javascript application/x-javascript text/javascript text/xml text/css;
+      log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                       '"$request" $status $body_bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+      access_log /var/spool/nginx/logs/access.log x-fwd;
     '';
   };
 }

--- a/modules/hydra-master-mantis.nix
+++ b/modules/hydra-master-mantis.nix
@@ -92,7 +92,7 @@ in {
       log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status $body_bytes_sent '
                        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-      access_log /var/spool/nginx/logs/access.log x-fwd;
+      access_log syslog:server=unix:/dev/log x-fwd;
     '';
   };
 }

--- a/modules/log-classifier-service.nix
+++ b/modules/log-classifier-service.nix
@@ -32,8 +32,15 @@ in {
       isSystemUser = true;
     };
     users.groups.log-classifier = { };
+    environment.systemPackages = with pkgs; [ goaccess ];
     services.nginx = {
       enable = true;
+      commonHttpConfig = ''
+        log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                         '"$request" $status $body_bytes_sent '
+                         '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+        access_log /var/spool/nginx/logs/access.log x-fwd;
+      '';
       virtualHosts."${cfg.domain}" = {
         enableACME = true;
         forceSSL = true;

--- a/modules/log-classifier-service.nix
+++ b/modules/log-classifier-service.nix
@@ -39,7 +39,7 @@ in {
         log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                          '"$request" $status $body_bytes_sent '
                          '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-        access_log /var/spool/nginx/logs/access.log x-fwd;
+        access_log syslog:server=unix:/dev/log x-fwd;
       '';
       virtualHosts."${cfg.domain}" = {
         enableACME = true;

--- a/modules/monitoring-rules-cardano.nix
+++ b/modules/monitoring-rules-cardano.nix
@@ -1,0 +1,32 @@
+{ ... }:
+
+# To be called from a monitoring-env-*.nix file for adding cardano service monitoring
+
+{
+  services.monitoring-services.applicationRules = [
+    {
+      alert = "chain_quality_degraded";
+      expr = "cardano_chain_quality_last_k__2160__blocks__ < 99";
+      for = "5m";
+      labels = {
+        severity = "page";
+      };
+      annotations = {
+        summary = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks.";
+        description = "{{$labels.alias}}: Degraded Chain Quality over last 2160 blocks (<99%).";
+      };
+    }
+    {
+      alert = "mempoolsize_tx_count_too_large";
+      expr = "max_over_time(cardano_MemPoolSize[5m]) > 190";
+      for = "1m";
+      labels = {
+        severity = "page";
+      };
+      annotations = {
+        summary = "{{$labels.alias}}: MemPoolSize tx count is larger than expected.";
+        description = "{{$labels.alias}}: When a node's MemPoolSize grows larger than the system can handle, transactions will be dropped. The actual thresholds for that in mainnet are unknown, but [based on benchmarks done beforehand](https://input-output-rnd.slack.com/archives/C2VJ41WDP/p1506563332000201) transactions started getting dropped when the MemPoolSize was ~200 txs.";
+      };
+    }
+  ];
+}

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -339,10 +339,17 @@ in {
     }))
     {
       networking.firewall.allowedTCPPorts = [ 80 ];
+      environment.systemPackages = with pkgs; [ goaccess ];
 
       services = {
         nginx = {
           enable = true;
+          commonHttpConfig = ''
+            log_format x-fwd '$remote_addr - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent '
+                             '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+            access_log /var/spool/nginx/logs/access.log x-fwd;
+          '';
           virtualHosts = {
             "${cfg.webhost}" = {
               locations = {

--- a/modules/monitoring-services.nix
+++ b/modules/monitoring-services.nix
@@ -348,7 +348,7 @@ in {
             log_format x-fwd '$remote_addr - $remote_user [$time_local] '
                              '"$request" $status $body_bytes_sent '
                              '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-            access_log /var/spool/nginx/logs/access.log x-fwd;
+            access_log syslog:server=unix:/dev/log x-fwd;
           '';
           virtualHosts = {
             "${cfg.webhost}" = {


### PR DESCRIPTION
Nginx related changes:
- Add goaccess and nginx XFF log headers
- Modify cardano-expl node service to 4096 NOFILE limit
- Switch nginx logging to /dev/log for journald target

Nix related changes:
- Add cardano monitoring rules module file
  - This allows us to pull in rules module files as needed rather than putting all the application rules directly in the environment deployment files.
  - Now used by the testnet deployment environment file