### PR TITLE
shell:  include 'genesis-tool' from 'cardano-node'

### DIFF
--- a/cardano-node-src.json
+++ b/cardano-node-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-node",
-  "rev": "44640f9cf02a49257edc14987c38bc85a2edf02f",
-  "sha256": "0cm6dvyq5ci8w10hb3csvh3kvgnwv20r9nc8s5g85ynygqfp89sr",
+  "rev": "6baf33e868f2d6c6a274213de553d15127a81c0b",
+  "sha256": "1bg1xc084lbh4mm7ca18cgkfyph1d5ln99vhqvq6qnwzqdxsn28p",
   "fetchSubmodules": false
 }

--- a/cardano-node-src.json
+++ b/cardano-node-src.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/input-output-hk/cardano-node",
+  "rev": "44640f9cf02a49257edc14987c38bc85a2edf02f",
+  "sha256": "0cm6dvyq5ci8w10hb3csvh3kvgnwv20r9nc8s5g85ynygqfp89sr",
+  "fetchSubmodules": false
+}

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ in
 , pkgs ? (import (localLib.nixpkgs) { inherit system crossSystem config; })
 , compiler ? pkgs.haskellPackages
 , cardanoRevOverride ? null
+, cardanoNodeRevOverride ? null
 , ...
 }@args:
 
@@ -37,6 +38,7 @@ let
 
   cardano-sl-pkgs = localLib.fetchProjectPackages "cardano-sl" <cardano-sl> ./.             cardanoRevOverride args;
   mantis-pkgs     = localLib.fetchProjectPackages "mantis"     <mantis>     ./goguen/pins   mantisRevOverride  args;
+  cardano-node-pkgs = localLib.fetchProjectPackages "cardano-node" <cardano-node> ./.       cardanoNodeRevOverride args;
 
   github-webhook-util = pkgs.callPackage ./github-webhook-util { };
 
@@ -68,7 +70,7 @@ let
   '';
 
 in {
-  inherit nixops iohk-ops iohk-ops-integration-test github-webhook-util;
+  inherit nixops iohk-ops iohk-ops-integration-test github-webhook-util cardano-node-pkgs;
   terraform = pkgs.callPackage ./terraform/terraform.nix {};
   mfa = pkgs.callPackage ./terraform/mfa.nix {};
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ let
   iohk-ops = iohkpkgs.iohk-ops;
   justIo = pkgs.mkShell {
     name = "io";
-    buildInputs = with pkgs; [ iohk-ops terraform_0_11 iohkpkgs.nixops ];
+    buildInputs = with pkgs; [ iohk-ops iohkpkgs.cardano-node-pkgs.nix-tools.exes.cardano-node terraform_0_11 iohkpkgs.nixops ];
     passthru = {
       inherit ioSelfBuild withAuxx;
     };


### PR DESCRIPTION
1. Pull in `cardano-node` packages 
2. Add `cardano-node`'s binaries to the shell, including `genesis-tool`.