### PR TITLE
GAC: Let consumers declare parameters

### DIFF
--- a/cardano-node-src.json
+++ b/cardano-node-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-node",
-  "rev": "6baf33e868f2d6c6a274213de553d15127a81c0b",
-  "sha256": "1bg1xc084lbh4mm7ca18cgkfyph1d5ln99vhqvq6qnwzqdxsn28p",
+  "rev": "d62b4550e462cc1ad4f1e86a2dbfb549d769ac4e",
+  "sha256": "0nvx1i53jagvfg4fw6wika8ck183if8qhqskcmcvif68b0spa2fg",
   "fetchSubmodules": false
 }

--- a/config.nix
+++ b/config.nix
@@ -1,5 +1,4 @@
 { deployerIP, accessKeyId, clusterName, tlsCert, tlsCertKey }:
-
 with (import <nixpkgs/lib>);
 
 filterAttrsRecursive (n: _: n != "_module") (evalModules {
@@ -13,5 +12,5 @@ filterAttrsRecursive (n: _: n != "_module") (evalModules {
       node = { inherit accessKeyId; };
       cluster = { inherit deployerIP tlsCert tlsCertKey; name = clusterName; };
     })
-  ];
+  ] ++ (optional (builtins.tryEval <local-module/parameters.nix>).success <local-module/parameters.nix>);
 }).config

--- a/modules/parameters.nix
+++ b/modules/parameters.nix
@@ -122,20 +122,10 @@
     };
     ##
     ##
-    hydra = mkOption {
-      description = "Hydra-specific parameters.";
-      default = {};
-      type = submodule {
-        options = {
-          ##
-          ## Non-mandatory configuration:
-          s3Bucket = mkOption {
-            type = nullOr str;
-            description = "Specify a bucket name to use an existing bucket to upload docker images to. If set to null (default) a bucket will be created.";
-            default = null;
-          };
-        };
-      };
+    hydra.s3Bucket = mkOption {
+      type = nullOr str;
+      description = "Specify a bucket name to use an existing bucket to upload docker images to. If set to null (default) a bucket will be created.";
+      default = null;
     };
   };
 }


### PR DESCRIPTION
Currently `config.nix` loads parameters from `modules/parameters.nix` and that
is hardcoded. As a result, repositories using GAC cannot declare their own
config parameters and must add those parameters here. This creates unnecessary
overhead/red-tape and is just not fun.

This:
1) changes the hydra parameter namespace from a nixos submodule to a regular
nested attrset; and
2) optionally loads `<local-module/parameters.nix>` if it exists.

Note that I'm still working on revisiting/simplifying the way this whole thing
works and this is just a (hopefully temporary) workaround to unblock my
hydra-notifications related work.