### PR TITLE
Feature: Support Niv sources in `gac`

### DIFF
--- a/gac.sh
+++ b/gac.sh
@@ -130,7 +130,7 @@ load_config
 ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ### gac.sh relies on ./default.nix providing the 'pkgs' and 'nixpkgs' attributes coming from iohk-nix.
 ###
-nixpkgs_out=$(nix-instantiate  --eval -E '(import ./. {}).nixpkgs'     | xargs echo)
+nixpkgs_out=$(nix-instantiate  --eval -E 'let inherit (import ./. {}) nixpkgs; in nixpkgs.outPath or nixpkgs'     | xargs echo)
 nix_out="$(   nix-build --no-out-link -E '(import ./. {}).pkgs.nix'    | xargs echo)"
 nixops_out="$(nix-build --no-out-link -E '(import ./. {}).pkgs.nixops' | xargs echo)"
 nix=${nix_out}/bin/nix


### PR DESCRIPTION
while retaining backward compatibility with our current pin mechanism.
Niv sources are `{ outPath = ... }` objects while oldschool pins are
"strings" (or ./paths? doesn't really matter).

I tested with both Niv and regular pins.


----

#