### PR TITLE
reduce the default pool size for postgresql connections

### DIFF
--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -71,6 +71,7 @@ in {
     extraConfig = ''
       max_output_size = 4294967296
       evaluator_max_heap_size = ${toString (5 * 1024 * 1024 * 1024)}
+      max_db_connections = 50
 
       max_concurrent_evals = 14
 


### PR DESCRIPTION
by default, postgresql allows 100 connections max
but hydra will keep the last 128 connections in a pool, causing problems