### PR TITLE
Make gac less dangerous

### DIFF
--- a/gac.sh
+++ b/gac.sh
@@ -319,8 +319,6 @@ destroy ) # Doc:
 delete ) # Doc:
         ${nixops} delete   "${nixops_subopts[@]}" "$@";;
 
-fromscratch | re | redeploy-cluster-from-scrach ) # Doc:
-        $self delete && $self create && $self deploy;;
 info   | i | nixops-info ) # Doc:
         ${nixops} info     "${nixops_subopts[@]}";;
 "" | "" ) # Doc:

--- a/gac.sh
+++ b/gac.sh
@@ -313,7 +313,7 @@ configure | config | cfg | conf | configure-nixops-deployment-arguments ) # Doc:
 genkey | g | generate-node-keys ) # Doc:
         generate_node_keys;;
 
-delete | destroy | terminate | abolish | eliminate | demolish | delete-nixops-deployment ) # Doc:
+delete | destroy ) # Doc:
         ${nixops} destroy  "${nixops_subopts[@]}"
         ${nixops} delete   "${nixops_subopts[@]}";;
 fromscratch | re | redeploy-cluster-from-scrach ) # Doc:

--- a/gac.sh
+++ b/gac.sh
@@ -313,9 +313,12 @@ configure | config | cfg | conf | configure-nixops-deployment-arguments ) # Doc:
 genkey | g | generate-node-keys ) # Doc:
         generate_node_keys;;
 
-delete | destroy ) # Doc:
-        ${nixops} destroy  "${nixops_subopts[@]}"
+destroy ) # Doc:
+        ${nixops} destroy  "${nixops_subopts[@]}";;
+
+delete ) # Doc:
         ${nixops} delete   "${nixops_subopts[@]}";;
+
 fromscratch | re | redeploy-cluster-from-scrach ) # Doc:
         $self delete && $self create && $self deploy;;
 info   | i | nixops-info ) # Doc:

--- a/gac.sh
+++ b/gac.sh
@@ -314,7 +314,7 @@ genkey | g | generate-node-keys ) # Doc:
         generate_node_keys;;
 
 destroy ) # Doc:
-        ${nixops} destroy  "${nixops_subopts[@]}";;
+        ${nixops} destroy  "${nixops_subopts[@]}" "$@";;
 
 delete ) # Doc:
         ${nixops} delete   "${nixops_subopts[@]}";;

--- a/gac.sh
+++ b/gac.sh
@@ -317,7 +317,7 @@ destroy ) # Doc:
         ${nixops} destroy  "${nixops_subopts[@]}" "$@";;
 
 delete ) # Doc:
-        ${nixops} delete   "${nixops_subopts[@]}";;
+        ${nixops} delete   "${nixops_subopts[@]}" "$@";;
 
 fromscratch | re | redeploy-cluster-from-scrach ) # Doc:
         $self delete && $self create && $self deploy;;

--- a/gac.sh
+++ b/gac.sh
@@ -314,7 +314,7 @@ genkey | g | generate-node-keys ) # Doc:
         generate_node_keys;;
 
 delete | destroy | terminate | abolish | eliminate | demolish | delete-nixops-deployment ) # Doc:
-        ${nixops} destroy  "${nixops_subopts[@]}" --confirm
+        ${nixops} destroy  "${nixops_subopts[@]}"
         ${nixops} delete   "${nixops_subopts[@]}";;
 fromscratch | re | redeploy-cluster-from-scrach ) # Doc:
         $self delete && $self create && $self deploy;;


### PR DESCRIPTION
I just had an issue with the monitoring instance of a cluster and
tried to `gac destroy --include monitoring`, fully expecting it to
behave like `gac deploy` (... or `nixops destroy`). To my horror, it
went ahead and nuked the entire cluster, automatically answering ‘yes’
to all the "ARE YOU SURE?!?!" prompts. Fortunately, this was just a
test cluster so nothing too bad happened. Upon looking at the code I
learned that:

1. `gac` clumps together `nixops destroy` and `nixops delete` under
   multiple aliases (including, but not limited to `gac destroy` and
   `gac delete`).
2. `gac destroy` passes the `--confirm` flag to `nixops destroy` which
   means that it will not stop to ask the user if they’re sure; and
3. The arguments passed to `gac destroy` aren’t relayed to `nixops
   destroy` (or `nixops delete`).

Hence, in order to enable the reasonable (I think?) use case I
described above, I have:

* Removed the `--confirm` flag: typing ‘y’ for each node is not nearly
  as bad as losing a production cluster.
* Removed all the aliases: it should be painfully clear what we’re
  doing when carrying out destructive operations.
* Split `gac destroy` to `gac destroy` and `gac delete`: it is
  possible that a user would want to destroy a cluster or a part
  thereof without wanting to delete the associated `nixops`
  deployment. And finally,
* Pass along the cli args to the respective `nixops` invocations: this
  enables the user to pass flags such as `--include`/`--exclude` or
  whatever their heart desires to `nixops destroy/delete`.

PS: I also removed `gac fromscratch` since it just clumps together
(the previous) `gac destroy` with `gac deploy` so it’s just as dangerous.