### PR TITLE
fix test-hydra-locally and add it to CI tests

### DIFF
--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -41,6 +41,7 @@ in pkgs.lib.fix (jobsets: {
       jobsets.iohk-ops.x86_64-linux
       (builtins.attrValues jobsets.tests)
       (builtins.attrValues jobsets.checks)
+      jobsets.tests.hydraLocally
     ];
   });
   nix-darwin = {

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -82,7 +82,7 @@ in {
 
       ${optionalString (builtins.pathExists ../static/github_token) ''
       <github_authorization>
-        input-output-hk = ${(builtins.readFile ../static/github_token) or ""}
+        input-output-hk = ${builtins.readFile ../static/github_token}
       </github_authorization>
       ''}
 

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -33,7 +33,7 @@ let
 in {
   environment.etc = lib.singleton {
     target = "nix/id_buildfarm";
-    source = if (builtins.pathExists ../static/id_buildfarm) then ../static/id_buildfarm else pkgs.writeText "build-farm" "";
+    source = if (builtins.pathExists ../static/id_buildfarm) then ../static/id_buildfarm else builtins.toFile "build-farm" "";
     uid = config.ids.uids.hydra-queue-runner;
     gid = config.ids.gids.hydra;
     mode = "0400";

--- a/modules/test-hydra-locally.nix
+++ b/modules/test-hydra-locally.nix
@@ -15,15 +15,19 @@ let
       graphics = false;
       qemu.networkingOptions = [
         "-net nic,netdev=user.0,model=virtio"
-        "-netdev user,id=user.0,hostfwd=tcp:127.0.0.1:8080-:80"
+        "-netdev user,id=user.0,hostfwd=tcp:127.0.0.1:8000-:8000"
       ];
     };
+    networking.firewall.allowedTCPPorts = [ 8000 ];
     services = {
       mingetty.autologinUser = "root";
       grafana.extraOptions.AUTH_GOOGLE_CLIENT_SECRET = lib.mkForce "";
+      hydra.hydraURL = lib.mkForce "http://localhost:8000";
+      monitoring-exporters.logging = false;
       nginx.virtualHosts."hydra.iohk.io" = {
         forceSSL = lib.mkForce false;
         enableACME = lib.mkForce false;
+        listen = lib.mkForce [ { addr = "0.0.0.0"; port = 8000; } ];
       };
     };
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -9,8 +9,11 @@ let
     inherit system;
   } // args);
   callTest = fn: args: forAllSystems (system: hydraJob (importTest fn args system));
+  hydraLocally = import ../modules/test-hydra-locally.nix;
 in rec {
+  inherit hydraLocally;
   # TODO: tests of images
   # simpleNode = callTest ./simple-node.nix {};
   # simpleNodeNixOps = callTest ./simple-node-nixops.nix {};
+
 }


### PR DESCRIPTION
Improved secrets management and moving all deployment.keys out of modules will clean this up further, but this is a work-around for now to get test-hydra-locally being built by CI.

This also completely removes github-webhook-util from hydra master as it isn't being used anymore.