### PR TITLE
Buildkite infra: Add NFS-shared build cache directory

### DIFF
--- a/modules/buildkite-cache-server.nix
+++ b/modules/buildkite-cache-server.nix
@@ -1,0 +1,42 @@
+# Module for a buildkite agent that NFS exports its cache to the given
+# list of clients.
+
+{ clients ? [] }:
+
+{ name, config, pkgs, lib, ... }:
+
+let
+  mkRulesHost = host: lib.concatMapStrings (mkRulesPort host) [4000 4001 4002];
+  mkRulesPort = host: port: lib.concatMapStrings (proto: ''
+    iptables -A INPUT -s ${host} -m state --state NEW -p ${proto} --dport ${toString port} -j ACCEPT
+  '') ["tcp" "udp"];
+
+in {
+  systemd.services.cache-dir = {
+    wantedBy = [ "nfs.service" "mnt-cache.mount" ];
+    before = [ "nfs.service" "mnt-cache.mount" ];
+    script = ''
+      mkdir -p /srv/nfs/cache
+      chown buildkite-agent:nogroup /srv/nfs/cache
+    '';
+    serviceConfig.Type = "oneshot";
+  };
+
+  fileSystems."/cache" = {
+    device = "/srv/nfs/cache";
+    fsType = "bind";
+  };
+
+  services.nfs = {
+    enable = true;
+    exports = ''
+      /srv/nfs/cache ${lib.concatMapStringsSep " " (h: "${h}(insecure,rw,root_squash,no_subtree_check)") clients}
+    '';
+    statdPort = 4000;
+    lockdPort = 4001;
+    mountdPort = 4002;
+    # hostName = name _ "-internal";
+  };
+
+  networking.firewall.extraCommands = lib.concatMapStrings mkRulesHost clients;
+}

--- a/modules/buildkite-cache.nix
+++ b/modules/buildkite-cache.nix
@@ -1,0 +1,18 @@
+# Module for a buildkite agent that mounts the NFS cache from the
+# given server.
+
+{ server }:
+
+{ config, pkgs, ... }:
+
+{
+  fileSystems."/cache" = {
+    device = "${server}:/srv/nfs/cache";
+    fsType = "nfs";
+    options = [ "soft" "x-systemd.automount" "noauto" ];
+  };
+
+  systemd.services."buildkite-agent.service" = {
+    wants = [ "mnt-cache.mount" ];
+  };
+}


### PR DESCRIPTION
Shares `/cache` among the Buildkite agents.

This is a draft PR because I haven't had time to test it.

I would like to use the packet.net internal network but the NixOps setup doesn't have IPs of the internal network interfaces in the hosts file.
