### PR TITLE
Jobsets: Add borsBuild and pr input arguments

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -296,6 +296,7 @@ let
       nixexprpath = "release.nix";
       inputs = {
         "${input}" = mkFetchGithub "${info.base.repo.clone_url} pull/${num}/head";
+        pr = { type = "string"; value = num; };
       };
     };
   };


### PR DESCRIPTION
This adds options for controlling the jobset size based on whether the Hydra build is for Bors or is a PR branch build.

This is useful to control CI load, since some test suites take 20-30 minutes to execute and don't need to be run on every commit on a PR branch.

* Adds a "borsBuild" string argument to the bors jobsets so that projects can build different jobs under Bors.

   For example, cardano-wallet could skip running the integration test suite unless the build is for Bors.

   The possible values of the "borsBuild" argument (if present) are "trying" and "staging".

* Adds a "pr" string argument to the GitHub PR jobsets. The value is the PR number.


Tested with:

    jq . < $(nix-build --no-out-link jobsets/default.nix)

After merging this, we need to monitor Hydra to check that evaluation is not broken.
