### PR TITLE
Enable bors for haskell.nix

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -181,6 +181,7 @@ let
       url = "https://github.com/input-output-hk/haskell.nix.git";
       branch = "master";
       prs = haskellNixPrsJSON;
+      bors = true;
     };
 
     cardano-wallet = {


### PR DESCRIPTION
I think we need this for https://github.com/input-output-hk/haskell.nix/pull/473